### PR TITLE
DB: Fix rarity of Armored Vaultbot

### DIFF
--- a/Options_Defaults.lua
+++ b/Options_Defaults.lua
@@ -4216,7 +4216,7 @@ function R:PrepareDefaults()
 		itemId = 170072,
 		creatureId = 155829,
 		questId = { 55546 },
-		chance = 20,
+		chance = 50,
 		coords = {
 			{ m = CONSTANTS.UIMAPIDS.MECHAGON_ISLAND, x =  53.99, y = 49.31, n = L["Armored Vaultbot"] },
 		},


### PR DESCRIPTION
Current rarity is 1 in 20 but according to my personal experience and the droprate its much more rare.
1.6%: https://www.wowhead.com/item=170072/armored-vaultbot