### PR TITLE
Fix incorrect covenant for Hopecrusher Gargon

### DIFF
--- a/Options_Defaults.lua
+++ b/Options_Defaults.lua
@@ -1458,7 +1458,7 @@ function R:PrepareDefaults()
 				{ m = CONSTANTS.UIMAPIDS.REVENDRETH, x = 46.0, y = 78.5, n = L["Harika the Horrid"] },
 			},
 			requiresCovenant = true,
-			requiredCovenantID = CONSTANTS.COVENANT_IDS.VENTYHR
+			requiredCovenantID = CONSTANTS.COVENANT_IDS.VENTHYR
 		},
 
 		["Bonehoof Tauralus"] = {
@@ -1492,7 +1492,7 @@ function R:PrepareDefaults()
 				{ m = CONSTANTS.UIMAPIDS.REVENDRETH, x = 51.98, y = 51.80, n = L["Hopecrusher"] },
 			},
 			requiresCovenant = true,
-			requiredCovenantID = CONSTANTS.COVENANT_IDS.NECROLORD
+			requiredCovenantID = CONSTANTS.COVENANT_IDS.VENTHYR
 		},
 
 		["Reins of the Colossal Slaughterclaw"] = {
@@ -1580,7 +1580,7 @@ function R:PrepareDefaults()
 				{ m = CONSTANTS.UIMAPIDS.MALDRAXXUS }
 			},
 		},
-     
+
 
 
 	--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -6928,7 +6928,7 @@ function R:PrepareDefaults()
 			method = SPECIAL,
 			name = L["Acrobatic Steward"],
 			itemId = 184418,
-			items = { 
+			items = {
 				353234,
 				353019,
 				353503,
@@ -6968,7 +6968,7 @@ function R:PrepareDefaults()
 		method = SPECIAL,
 		name = L["Soothing Vesper"],
 		itemId = 184415,
-		items = { 
+		items = {
 			353687,
 			353691,
 			353867


### PR DESCRIPTION
**Hopecrusher Gargon** drops for **Venthyr** and not **Necrolord**. I also noticed that the constant was spelt incorrectly for **Harika the Horrid**.

My editor also stripped some white space. Sorry if that is an issue.