### PR TITLE
Add Impressionable Gorger Spawn (Loyal Gorger)

### DIFF
--- a/Locales.lua
+++ b/Locales.lua
@@ -1601,6 +1601,8 @@ L["Contained Essence of Dread"] = true
 L["Eternas the Tormentor"] = true
 L["Tower Deathroach"] = true
 L["Decayspeaker"] = true
+L["Impressionable Gorger Spawn"] = true
+L["Worldedge Gorger"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Options_Defaults.lua
+++ b/Options_Defaults.lua
@@ -2298,10 +2298,24 @@ function R:PrepareDefaults()
 			},
 		},
 
-    },
+		["Impressionable Gorger Spawn"] = {
+			cat = SHADOWLANDS,
+			type = MOUNT,
+			method = NPC,
+			name = L["Impressionable Gorger Spawn"],
+			itemId = 180583,
+			spellId = 333027,
+			npcs = { 160821 },
+			chance = 100, -- Estimate,
+			questId = 58259,
+			groupSize = 5,
+			equalOdds = true,
+			coords = {
+				{ m = CONSTANTS.UIMAPIDS.REVENDRETH, x = 38.60, y = 72.00, n = L["Worldedge Gorger"] },
+			},
+		},
 
-
-
+		},
 
 				--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 				-- BATTLE PETS


### PR DESCRIPTION
This is a little different to most mounts that drop from NPC's.

The [Impressionable Gorger Spawn](https://www.wowhead.com/item=180583/impressionable-gorger-spawn#comments) has a chance to drop from the [Worldedge Gorger](https://www.wowhead.com/npc=160821/worldedge-gorger). 

This item starts a quest chain where you have to complete a daily quest 7(?) times. After that you will learn the [Loyal Gorger](https://www.wowhead.com/spell=333027/loyal-gorger).

I used the [Torn Invitation](https://github.com/SacredDuckwhale/Rarity/blob/1809d53b8abbf4bf492a43602d2c662b155c23e6/Options_Defaults.lua#L715) as a template, since that is also an item which doesn't directly give you the mount.