### PR TITLE
Some missing data in the lastest releases

### DIFF
--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -1189,6 +1189,24 @@ function R:OnEvent(event, ...)
 			end
 		end
 
+		-- Handle opening Cache of the Ascended (Shadowlands, Bastion mount cache)
+		if Rarity.isFishing and Rarity.isOpening and Rarity.lastNode and (Rarity.lastNode == L["Cache of the Ascended"]) then
+			local names = {"Ascended Skymane"}
+			Rarity:Debug("Detected Opening on " .. L["Cache of the Ascended"] .. " (method = SPECIAL)")
+			for _, name in pairs(names) do
+				local v = self.db.profile.groups.items[name] or self.db.profile.groups.mounts[name]
+				if v and type(v) == "table" and v.enabled ~= false then
+					if v.attempts == nil then
+						v.attempts = 1
+					else
+						v.attempts = v.attempts + 1
+					end
+					self:OutputAttempts(v)
+				end
+			end
+		end
+
+
 		-- Handle opening Pile of Coins
 		if Rarity.isFishing and Rarity.isOpening and Rarity.lastNode and (Rarity.lastNode == L["Pile of Coins"]) then
 			local names = {"Armored Vaultbot"}

--- a/DB/Nodes.lua
+++ b/DB/Nodes.lua
@@ -221,4 +221,5 @@ R.opennodes = {
 	[L["Gilded Chest"]] = true,
 	[L["Broken Bell"]] = true,
 	[L["Skyward Bell"]] = true,
+	[L["Cache of the Ascended"]] = true
 }

--- a/Locales.lua
+++ b/Locales.lua
@@ -1598,6 +1598,7 @@ L["Contained Essence of Dread"] = true
 L["Eternas the Tormentor"] = true
 L["Tower Deathroach"] = true
 L["Decayspeaker"] = true
+L["Cache of the Ascended"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Options_Defaults.lua
+++ b/Options_Defaults.lua
@@ -5449,6 +5449,7 @@ function R:PrepareDefaults()
 		spellId = 333795,
 		creatureId = 171118,
 		npcs = { 170048, 165175 },
+		questId = { 60729 },
 		chance = 20,
 		coords = {
 			{ m = CONSTANTS.UIMAPIDS.REVENDRETH, x = 49.84, y = 35.02, n = L["Manifestation of Wrath"] },

--- a/Options_Defaults.lua
+++ b/Options_Defaults.lua
@@ -2296,6 +2296,24 @@ function R:PrepareDefaults()
 			},
 		},
 
+		["Ascended Skymane"] = {
+			cat = SHADOWLANDS,
+			type = MOUNT,
+			method = SPECIAL,
+			name = L["Ascended Skymane"],
+			spellId = 342335,
+			itemId = 183741,
+			items = { 354175 },
+			chance = 20,
+			tooltipNpcs = { 170834, 170835, 170833, 170832, 170836 },
+			questId = { 60933 },
+			groupSize = 5,
+			equalOdds = true,
+			coords = {
+				{ m = CONSTANTS.UIMAPIDS.BASTION, x = 53.50, y = 88.37, n = L["Cache of the Ascended"] },
+			},
+		},
+
     },
 
 

--- a/Options_Defaults.lua
+++ b/Options_Defaults.lua
@@ -5417,6 +5417,7 @@ function R:PrepareDefaults()
 		creatureId = 171714,
 		npcs = { 171041, 171013, 171040 },
 		chance = 20,
+		questId = 61001,
 		coords = {
 			{ m = CONSTANTS.UIMAPIDS.BASTION },
 		},


### PR DESCRIPTION
I've added a missing mount called [Ascended Skymane](https://www.wowhead.com/item=183741/ascended-skymane) which drops from a rare event in Bastion. It requires a group to summon and spawns a cache which may contain a mount upon defeat.

Also added questId for two pet rare drops: Devoured Wader & Bottled Up Rage