### PR TITLE
DB: Added missing mount: Ascended Skymane

### DIFF
--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -1189,6 +1189,23 @@ function R:OnEvent(event, ...)
 			end
 		end
 
+		-- Handle opening Cache of the Ascended (Shadowlands, Bastion mount cache)
+		if Rarity.isFishing and Rarity.isOpening and Rarity.lastNode and (Rarity.lastNode == L["Cache of the Ascended"]) then
+			local names = {"Ascended Skymane"}
+			Rarity:Debug("Detected Opening on " .. L["Cache of the Ascended"] .. " (method = SPECIAL)")
+			for _, name in pairs(names) do
+				local v = self.db.profile.groups.items[name] or self.db.profile.groups.mounts[name]
+				if v and type(v) == "table" and v.enabled ~= false then
+					if v.attempts == nil then
+						v.attempts = 1
+					else
+						v.attempts = v.attempts + 1
+					end
+					self:OutputAttempts(v)
+				end
+			end
+		end
+
 		-- Handle opening Pile of Coins
 		if Rarity.isFishing and Rarity.isOpening and Rarity.lastNode and (Rarity.lastNode == L["Pile of Coins"]) then
 			local names = {"Armored Vaultbot"}

--- a/DB/Nodes.lua
+++ b/DB/Nodes.lua
@@ -221,4 +221,5 @@ R.opennodes = {
 	[L["Gilded Chest"]] = true,
 	[L["Broken Bell"]] = true,
 	[L["Skyward Bell"]] = true,
+	[L["Cache of the Ascended"]] = true
 }

--- a/Locales.lua
+++ b/Locales.lua
@@ -1603,6 +1603,7 @@ L["Tower Deathroach"] = true
 L["Decayspeaker"] = true
 L["Impressionable Gorger Spawn"] = true
 L["Worldedge Gorger"] = true
+L["Cache of the Ascended"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Options_Defaults.lua
+++ b/Options_Defaults.lua
@@ -2315,6 +2315,24 @@ function R:PrepareDefaults()
 			},
 		},
 
+		["Ascended Skymane"] = {
+			cat = SHADOWLANDS,
+			type = MOUNT,
+			method = SPECIAL,
+			name = L["Ascended Skymane"],
+			spellId = 342335,
+			itemId = 183741,
+			items = { 354175 },
+			chance = 20,
+			tooltipNpcs = { 170834, 170835, 170833, 170832, 170836 },
+			questId = { 60933 },
+			groupSize = 5,
+			equalOdds = true,
+			coords = {
+				{ m = CONSTANTS.UIMAPIDS.BASTION, x = 53.50, y = 88.37, n = L["Cache of the Ascended"] },
+			},
+		},
+
 		},
 
 				--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Added a missing 9.0 mount to the database. This is a rare event which ends with a cache that may contain this mount
https://www.wowhead.com/item=183741/ascended-skymane