### PR TITLE
DB: Added defeat detection and tooltipNPC for Sabriel the Bonecleaver

### DIFF
--- a/Options_Defaults.lua
+++ b/Options_Defaults.lua
@@ -2220,6 +2220,8 @@ function R:PrepareDefaults()
 			spellId = 332466,
 			npcs = { 168147 },
 			chance = 100,	-- Estimate
+			questId = { 58784 },
+			tooltipNpcs = { 168148 },
 			groupSize = 5,
 			equalOdds = true,
 			coords = {
@@ -2238,6 +2240,8 @@ function R:PrepareDefaults()
 			spellId = 332482,
 			npcs = { 168147 },
 			chance = 100,	-- Estimate
+			questId = { 58784 },
+			tooltipNpcs = { 168148 },
 			groupSize = 5,
 			equalOdds = true,
 			coords = {


### PR DESCRIPTION
Added defeat detection and a tooltipNPC for Sabriel the Bonecleaver's two mount drops. One of these are still not confirmed dropping on live, as this is one of the first days he is up - but as the mount is already in the DB, I updated the detection for both