### PR TITLE
DB: Added Skittering Venomspitter (pet)

### DIFF
--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -1223,6 +1223,23 @@ function R:OnEvent(event, ...)
 			end
 		end
 
+		-- Handle opening Sprouting Growth (Shadowlands, Maldraxxus crate for Skittering Venomspitter pet)
+		if Rarity.isFishing and Rarity.isOpening and Rarity.lastNode and (Rarity.lastNode == L["Sprouting Growth"]) then
+			local names = {"Skittering Venomspitter"}
+			Rarity:Debug("Detected Opening on " .. L["Sprouting Growth"] .. " (method = SPECIAL)")
+			for _, name in pairs(names) do
+				local v = self.db.profile.groups.items[name] or self.db.profile.groups.pets[name]
+				if v and type(v) == "table" and v.enabled ~= false then
+					if v.attempts == nil then
+						v.attempts = 1
+					else
+						v.attempts = v.attempts + 1
+					end
+					self:OutputAttempts(v)
+				end
+			end
+		end
+
 		-- Handle opening Pile of Coins
 		if Rarity.isFishing and Rarity.isOpening and Rarity.lastNode and (Rarity.lastNode == L["Pile of Coins"]) then
 			local names = {"Armored Vaultbot"}

--- a/DB/Nodes.lua
+++ b/DB/Nodes.lua
@@ -222,5 +222,6 @@ R.opennodes = {
 	[L["Broken Bell"]] = true,
 	[L["Skyward Bell"]] = true,
 	[L["Cache of the Ascended"]] = true,
-	[L["Slime-Coated Crate"]] = true
+	[L["Slime-Coated Crate"]] = true,
+	[L["Sprouting Growth"]] = true
 }

--- a/Locales.lua
+++ b/Locales.lua
@@ -1622,6 +1622,8 @@ L["Filthy Bucket"] = true
 L["Gol'than the Malodorous"] = true
 L["Slime-Coated Crate"] = true
 L["Kevin's Party Supplies"] = true
+L["Sprouting Growth"] = true
+L["Skittering Venomspitter"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Options_Defaults.lua
+++ b/Options_Defaults.lua
@@ -5797,6 +5797,20 @@ function R:PrepareDefaults()
 		},
 	},
 
+	["Skittering Venomspitter"] = {
+		cat = SHADOWLANDS,
+		type = PET,
+		method = SPECIAL,
+		name = L["Skittering Venomspitter"],
+		itemId = 181173,
+		spellId = 335765,
+		creatureId = 171987,
+		chance = 75,
+		coords = {
+			{ m = CONSTANTS.UIMAPIDS.MALDRAXXUS },
+		},
+	},
+
 },
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 				-- TOYS AND ITEMS


### PR DESCRIPTION
Added another missing pet from 9.0. This time it's the [Skittering Venomspitter](https://www.wowhead.com/item=181173/skittering-venomspitter) which is contained in a 'chest' in Maldraxxus