### PR TITLE
DB: Added Bubbling Pustule (pet)

### DIFF
--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -1206,12 +1206,12 @@ function R:OnEvent(event, ...)
 			end
 		end
 
-		-- Handle opening Slime-Coated Crate (Shadowlands, Maldraxxus crate for Kevin's Party Supplies toy)
+		-- Handle opening Slime-Coated Crate (Shadowlands, Maldraxxus crate for Kevin's Party Supplies (toy) & Bubbling Pustule (pet))
 		if Rarity.isFishing and Rarity.isOpening and Rarity.lastNode and (Rarity.lastNode == L["Slime-Coated Crate"]) then
-			local names = {"Kevin's Party Supplies"}
+			local names = {"Kevin's Party Supplies", "Bubbling Pustule"}
 			Rarity:Debug("Detected Opening on " .. L["Slime-Coated Crate"] .. " (method = SPECIAL)")
 			for _, name in pairs(names) do
-				local v = self.db.profile.groups.items[name] or self.db.profile.groups.mounts[name]
+				local v = self.db.profile.groups.items[name] or self.db.profile.groups.pets[name]
 				if v and type(v) == "table" and v.enabled ~= false then
 					if v.attempts == nil then
 						v.attempts = 1

--- a/Locales.lua
+++ b/Locales.lua
@@ -1624,6 +1624,7 @@ L["Slime-Coated Crate"] = true
 L["Kevin's Party Supplies"] = true
 L["Sprouting Growth"] = true
 L["Skittering Venomspitter"] = true
+L["Bubbling Pustule"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Options_Defaults.lua
+++ b/Options_Defaults.lua
@@ -5811,6 +5811,20 @@ function R:PrepareDefaults()
 		},
 	},
 
+	["Bubbling Pustule"] = {
+		cat = SHADOWLANDS,
+		type = PET,
+		method = SPECIAL,
+		name = L["Bubbling Pustule"],
+		itemId = 181262,
+		spellId = 335966,
+		creatureId = 172132,
+		chance = 33,
+		coords = {
+			{ m = CONSTANTS.UIMAPIDS.MALDRAXXUS },
+		},
+	},
+
 },
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 				-- TOYS AND ITEMS


### PR DESCRIPTION
Added the 9.0 pet [Bubbling Pustule](https://www.wowhead.com/item=181262/bubbling-pustule)
This is a drop contained in Slime-Coated Crate, a chest that got implemented a couple commits ago related to a toy. Code is modified to count both items