### PR TITLE
DB: Added Trapped Stonefiend (pet)

### DIFF
--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -1257,6 +1257,23 @@ function R:OnEvent(event, ...)
 			end
 		end
 
+		-- Handle opening Bleakwood Chest (Shadowlands, Revendreth chest for Trapped Stonefiend pet)
+		if Rarity.isFishing and Rarity.isOpening and Rarity.lastNode and (Rarity.lastNode == L["Bleakwood Chest"]) then
+			local names = {"Trapped Stonefiend"}
+			Rarity:Debug("Detected Opening on " .. L["Bleakwood Chest"] .. " (method = SPECIAL)")
+			for _, name in pairs(names) do
+				local v = self.db.profile.groups.items[name] or self.db.profile.groups.pets[name]
+				if v and type(v) == "table" and v.enabled ~= false then
+					if v.attempts == nil then
+						v.attempts = 1
+					else
+						v.attempts = v.attempts + 1
+					end
+					self:OutputAttempts(v)
+				end
+			end
+		end
+
 		-- Handle opening Pile of Coins
 		if Rarity.isFishing and Rarity.isOpening and Rarity.lastNode and (Rarity.lastNode == L["Pile of Coins"]) then
 			local names = {"Armored Vaultbot"}

--- a/DB/Nodes.lua
+++ b/DB/Nodes.lua
@@ -224,5 +224,6 @@ R.opennodes = {
 	[L["Cache of the Ascended"]] = true,
 	[L["Slime-Coated Crate"]] = true,
 	[L["Sprouting Growth"]] = true,
-	[L["Stewart's Stewpendous Stew"]] = true
+	[L["Stewart's Stewpendous Stew"]] = true,
+	[L["Bleakwood Chest"]] = true
 }

--- a/Locales.lua
+++ b/Locales.lua
@@ -1628,6 +1628,8 @@ L["Bubbling Pustule"] = true
 L["Silvershell Snapper"] = true
 L["This can be looted after killing Dionae."] = true
 L["Stewart's Stewpendous Stew"] = true
+L["Bleakwood Chest"] = true
+L["Trapped Stonefiend"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Options_Defaults.lua
+++ b/Options_Defaults.lua
@@ -5842,6 +5842,20 @@ function R:PrepareDefaults()
 		},
 	},
 
+	["Trapped Stonefiend"] = {
+		cat = SHADOWLANDS,
+		type = PET,
+		method = SPECIAL,
+		name = L["Trapped Stonefiend"],
+		itemId = 180592,
+		spellId = 333803,
+		creatureId = 171125,
+		chance = 10,
+		coords = {
+			{ m = CONSTANTS.UIMAPIDS.REVENDRETH },
+		},
+	},
+
 },
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 				-- TOYS AND ITEMS


### PR DESCRIPTION
Added the 9.0 pet [Trapped Stonefiend](https://www.wowhead.com/item=180592/trapped-stonefiend). This can drop from [Bleakwood Chest](https://www.wowhead.com/object=353232/bleakwood-chest) in Revendreth.