### PR TITLE
Added mount/item/pet filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 # Embedded libraries that are used for local testing only
 Libs/
 *.CMD
+*.suo
+*.json
+*.sqlite

--- a/Core/GUI.lua
+++ b/Core/GUI.lua
@@ -104,6 +104,11 @@ local yellow = {r = 1.0, g = 1.0, b = 0.2}
 local gray = {r = 0.5, g = 0.5, b = 0.5}
 local white = {r = 1.0, g = 1.0, b = 1.0}
 
+-- Types of items
+local MOUNT = "MOUNT"
+local PET = "PET"
+local ITEM = "ITEM"
+
 -- Helper function (to look up map names more easily)
 -- TODO: DRY (not sure where this fits best, move after refactoring the rest and delete any duplicates)
 -- Returns the localized map name, or nil if the uiMapID is invalid
@@ -1745,34 +1750,41 @@ function R:ShowTooltip(hidden)
 	local somethingAdded = false
 
 	local group1start = debugprofilestop()
-	addedLast, itemsExistInThisGroup = addGroup(self.db.profile.groups.mounts)
+	if(R.db.profile.collectionType[MOUNT]) then		
+		addedLast, itemsExistInThisGroup = addGroup(self.db.profile.groups.mounts)
+		
+		if addedLast then
+			tooltip:AddSeparator(1, 1, 1, 1, 1.0)
+		end
+		if itemsExistInThisGroup then
+			somethingAdded = true
+		end
+	end
 	local group1end = debugprofilestop()
-	if addedLast then
-		tooltip:AddSeparator(1, 1, 1, 1, 1.0)
-	end
-	if itemsExistInThisGroup then
-		somethingAdded = true
-	end
 
 	local group2start = debugprofilestop()
-	addedLast, itemsExistInThisGroup = addGroup(self.db.profile.groups.pets)
+	if(R.db.profile.collectionType[PET]) then		
+		addedLast, itemsExistInThisGroup = addGroup(self.db.profile.groups.pets)
+		if addedLast then
+			tooltip:AddSeparator(1, 1, 1, 1, 1.0)
+		end
+		if itemsExistInThisGroup then
+			somethingAdded = true
+		end
+	end
 	local group2end = debugprofilestop()
-	if addedLast then
-		tooltip:AddSeparator(1, 1, 1, 1, 1.0)
-	end
-	if itemsExistInThisGroup then
-		somethingAdded = true
-	end
 
 	local group3start = debugprofilestop()
-	addedLast, itemsExistInThisGroup = addGroup(self.db.profile.groups.items)
+	if(R.db.profile.collectionType[ITEM]) then
+		addedLast, itemsExistInThisGroup = addGroup(self.db.profile.groups.items)		
+		if addedLast then
+			tooltip:AddSeparator(1, 1, 1, 1, 1.0)
+		end
+		if itemsExistInThisGroup then
+			somethingAdded = true
+		end
+	end
 	local group3end = debugprofilestop()
-	if addedLast then
-		tooltip:AddSeparator(1, 1, 1, 1, 1.0)
-	end
-	if itemsExistInThisGroup then
-		somethingAdded = true
-	end
 
 	local group4start = debugprofilestop()
 	addedLast, itemsExistInThisGroup = addGroup(self.db.profile.groups.user)
@@ -1785,34 +1797,40 @@ function R:ShowTooltip(hidden)
 	end
 
 	local group5start = debugprofilestop()
-	addedLast, itemsExistInThisGroup = addGroup(self.db.profile.groups.mounts, true)
+	if(R.db.profile.collectionType[MOUNT]) then
+		addedLast, itemsExistInThisGroup = addGroup(self.db.profile.groups.mounts, true)
+		if addedLast then
+			tooltip:AddSeparator(1, 1, 1, 1, 1.0)
+		end
+		if itemsExistInThisGroup then
+			somethingAdded = true
+		end
+	end
 	local group5end = debugprofilestop()
-	if addedLast then
-		tooltip:AddSeparator(1, 1, 1, 1, 1.0)
-	end
-	if itemsExistInThisGroup then
-		somethingAdded = true
-	end
 
 	local group6start = debugprofilestop()
-	addedLast, itemsExistInThisGroup = addGroup(self.db.profile.groups.pets, true)
+	if(R.db.profile.collectionType[PET]) then
+		addedLast, itemsExistInThisGroup = addGroup(self.db.profile.groups.pets, true)
+		if addedLast then
+			tooltip:AddSeparator(1, 1, 1, 1, 1.0)
+		end
+		if itemsExistInThisGroup then
+			somethingAdded = true
+		end
+	end
 	local group6end = debugprofilestop()
-	if addedLast then
-		tooltip:AddSeparator(1, 1, 1, 1, 1.0)
-	end
-	if itemsExistInThisGroup then
-		somethingAdded = true
-	end
 
 	local group7start = debugprofilestop()
-	addedLast, itemsExistInThisGroup = addGroup(self.db.profile.groups.items, true)
+	if(R.db.profile.collectionType[ITEM]) then
+		addedLast, itemsExistInThisGroup = addGroup(self.db.profile.groups.items, true)
+		if addedLast then
+			tooltip:AddSeparator(1, 1, 1, 1, 1.0)
+		end
+		if itemsExistInThisGroup then
+			somethingAdded = true
+		end
+	end
 	local group7end = debugprofilestop()
-	if addedLast then
-		tooltip:AddSeparator(1, 1, 1, 1, 1.0)
-	end
-	if itemsExistInThisGroup then
-		somethingAdded = true
-	end
 
 	local group8start = debugprofilestop()
 	addedLast, itemsExistInThisGroup = addGroup(self.db.profile.groups.user, true)

--- a/Locales.lua
+++ b/Locales.lua
@@ -1630,6 +1630,8 @@ L["This can be looted after killing Dionae."] = true
 L["Stewart's Stewpendous Stew"] = true
 L["Bleakwood Chest"] = true
 L["Trapped Stonefiend"] = true
+L["Collectable Type Filter"] = true
+L["These toggles filter which items appear in the main Rarity tooltip. Items are categorized by their type (eg. Mounts, Battle Pets...). Turning off these checkboxes does not turn off tracking for any items within the category; it simply hides the item from the tooltip in order to help reduce the number of items in it."] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Modules/Options/Options.lua
+++ b/Modules/Options/Options.lua
@@ -787,6 +787,51 @@ function R:PrepareOptions()
 						}, -- args
 					}, -- contentCategory
 
+					collectionType = {
+						type = "group",
+						name = L["Collectable Type Filter"],
+						order = newOrder(),
+						inline = true,
+						args = {
+
+						desc = {
+							type = "description",
+							name = L["These toggles filter which items appear in the main Rarity tooltip. Items are categorized by their type (eg. Mounts, Battle Pets...). Turning off these checkboxes does not turn off tracking for any items within the category; it simply hides the item from the tooltip in order to help reduce the number of items in it."],
+							order = newOrder(),
+						},
+					  mounts = {
+						  type = "toggle",
+						  order = newOrder(),
+						  name = L["Mounts"],
+						  get = function() return self.db.profile.collectionType[MOUNT] end,
+						  set = function(info, val)
+							  self.db.profile.collectionType[MOUNT] = val
+							  Rarity.GUI:UpdateText()
+						  end,
+					  },
+					  pets = {
+						  type = "toggle",
+						  order = newOrder(),
+						  name = L["Battle Pets"],
+						  get = function() return self.db.profile.collectionType[PET] end,
+						  set = function(info, val)
+							  self.db.profile.collectionType[PET] = val
+							  Rarity.GUI:UpdateText()
+						  end,
+					  },
+					  items = {
+						  type = "toggle",
+						  order = newOrder(),
+						  name = L["Toys & Items"],
+						  get = function() return self.db.profile.collectionType[ITEM] end,
+						  set = function(info, val)
+							  self.db.profile.collectionType[ITEM] = val
+							  Rarity.GUI:UpdateText()
+						  end,
+					  },
+
+						}, --args
+					}, -- collectionType
 
 					bar = {
 						type = "group",

--- a/Options_Defaults.lua
+++ b/Options_Defaults.lua
@@ -242,6 +242,12 @@ function R:PrepareDefaults()
 				[SHADOWLANDS] = true,
 			},
 
+			collectionType = {
+				[MOUNT] = true,
+				[PET] = true,
+				[ITEM] = true,
+			},
+
 			-- These are achievements with the names of rare NPCs as criteria to kill
 			achNpcs = {
 				-- Burning Crusade


### PR DESCRIPTION
I've added a config menu to toggle Mounts, Battle Pets, and Toys & Items to be displayed by the tooltip.
The rationale was huge performance drops when opening the tooltip when I only really want to display mounts at the moment. Filtering out the unneeded collections makes it significantly quicker for me.

![image](https://user-images.githubusercontent.com/1252123/106611800-4becad80-6560-11eb-90b9-59570d4d5e93.png)

Also, sorry about the crud added to the .gitignore, it's from Visual Studio :) 