### PR TITLE
DB: Updated Tower Deathroach's source and chance

### DIFF
--- a/Locales.lua
+++ b/Locales.lua
@@ -1614,7 +1614,6 @@ L["Corpselouse Larva"] = true
 L["Contained Essence of Dread"] = true
 L["Eternas the Tormentor"] = true
 L["Tower Deathroach"] = true
-L["Decayspeaker"] = true
 L["Impressionable Gorger Spawn"] = true
 L["Worldedge Gorger"] = true
 L["Cache of the Ascended"] = true

--- a/Options_Defaults.lua
+++ b/Options_Defaults.lua
@@ -5445,13 +5445,13 @@ function R:PrepareDefaults()
 		type = PET,
 		method = NPC,
 		name = L["Tower Deathroach"],
-		npcs = { 155250 },
+		npcs = { 155250, 155251, 156239 },
 		spellId = 340721,
 		itemId = 183115,
-		chance = 12,
+		chance = 25,
 		creatureId = 173849,
 		coords = {
-			{ m = CONSTANTS.UIMAPIDS.TORGHAST, n = L["Decayspeaker"] },
+			{ m = CONSTANTS.UIMAPIDS.TORGHAST },
 		},
 	},
 


### PR DESCRIPTION
This [pet ](https://www.wowhead.com/item=183115/tower-deathroach)is dropping from multiple bosses within Torghast and not just the one that was listed. I only noticed because I had it drop from another boss. Also updated the drop chance to a better approximation