### PR TITLE
Added the pets from Alchemy

### DIFF
--- a/Locales.lua
+++ b/Locales.lua
@@ -1636,6 +1636,7 @@ L["Undulating Blue Sac"] = true
 L["Baby Crawg"] = true
 L["Ball of Tentacles"] = true
 L["Ridgeback Piglet"] = true
+L["Thaumaturgical Piglet"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Locales.lua
+++ b/Locales.lua
@@ -1637,6 +1637,7 @@ L["Baby Crawg"] = true
 L["Ball of Tentacles"] = true
 L["Ridgeback Piglet"] = true
 L["Thaumaturgical Piglet"] = true
+L["Transmutant"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Locales.lua
+++ b/Locales.lua
@@ -1631,6 +1631,7 @@ L["Bleakwood Chest"] = true
 L["Trapped Stonefiend"] = true
 L["Collectable Type Filter"] = true
 L["These toggles filter which items appear in the main Rarity tooltip. Items are categorized by their type (eg. Mounts, Battle Pets...). Turning off these checkboxes does not turn off tracking for any items within the category; it simply hides the item from the tooltip in order to help reduce the number of items in it."] = true
+L["Wind-Up Frog"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Locales.lua
+++ b/Locales.lua
@@ -1635,6 +1635,7 @@ L["Wind-Up Frog"] = true
 L["Undulating Blue Sac"] = true
 L["Baby Crawg"] = true
 L["Ball of Tentacles"] = true
+L["Ridgeback Piglet"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Locales.lua
+++ b/Locales.lua
@@ -1633,6 +1633,7 @@ L["Collectable Type Filter"] = true
 L["These toggles filter which items appear in the main Rarity tooltip. Items are categorized by their type (eg. Mounts, Battle Pets...). Turning off these checkboxes does not turn off tracking for any items within the category; it simply hides the item from the tooltip in order to help reduce the number of items in it."] = true
 L["Wind-Up Frog"] = true
 L["Undulating Blue Sac"] = true
+L["Baby Crawg"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Locales.lua
+++ b/Locales.lua
@@ -1634,6 +1634,7 @@ L["These toggles filter which items appear in the main Rarity tooltip. Items are
 L["Wind-Up Frog"] = true
 L["Undulating Blue Sac"] = true
 L["Baby Crawg"] = true
+L["Ball of Tentacles"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Locales.lua
+++ b/Locales.lua
@@ -1632,6 +1632,7 @@ L["Trapped Stonefiend"] = true
 L["Collectable Type Filter"] = true
 L["These toggles filter which items appear in the main Rarity tooltip. Items are categorized by their type (eg. Mounts, Battle Pets...). Turning off these checkboxes does not turn off tracking for any items within the category; it simply hides the item from the tooltip in order to help reduce the number of items in it."] = true
 L["Wind-Up Frog"] = true
+L["Undulating Blue Sac"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Options_Defaults.lua
+++ b/Options_Defaults.lua
@@ -2524,6 +2524,18 @@ function R:PrepareDefaults()
 			chance = 10,
 	 },
 
+	 ["Thaumaturgical Piglet"] = {
+			cat = LEGION,
+			type = PET,
+			method = USE,
+			name = L["Thaumaturgical Piglet"],
+			spellId = 210681,
+			itemId = 136908,
+			creatureId = 98183,
+			items = { 137608 },
+			chance = 10,
+	 },
+
      --["Sting Ray Pup"] =                                 { cat = LEGION, type = PET, method = COLLECTION, name = L["Sting Ray Pup"], spellId = 217218, itemId = 138810, creatureId = 109216, collectedItemId = { 138777 }, chance = 50, },
 					-- 7.1
 	 ["Blessed Seed"] =									 { cat = LEGION, type = PET, method = NPC, name = L["Blessed Seed"], itemId = 142091, spellId = 229098, creatureId = 115143, npcs = { 32906 }, chance = 10, statisticId = {2864, 3258}, doNotUpdateToHighestStat = true,  coords = {{m=148,x=53.2,y=22.3,i=true}},},

--- a/Options_Defaults.lua
+++ b/Options_Defaults.lua
@@ -3282,6 +3282,18 @@ function R:PrepareDefaults()
 			chance = 50,
 		},
 
+		["Undulating Blue Sac"] = {
+			cat = BFA,
+			type = PET,
+			method = USE,
+			name = L["Undulating Blue Sac"],
+			spellId = 280618,
+			itemId = 163861,
+			creatureId = 143958,
+			items = { 160324 },
+			chance = 50,
+		},
+
 		-- 8.1 Pets
 
 		["Albatross Feather"] = {

--- a/Options_Defaults.lua
+++ b/Options_Defaults.lua
@@ -3294,6 +3294,18 @@ function R:PrepareDefaults()
 			chance = 50,
 		},
 
+		["Baby Crawg"] = {
+			cat = BFA,
+			type = PET,
+			method = USE,
+			name = L["Baby Crawg"],
+			spellId = 279435,
+			itemId = 163859,
+			creatureId = 143374,
+			items = { 160324 },
+			chance = 50,
+		},
+
 		-- 8.1 Pets
 
 		["Albatross Feather"] = {

--- a/Options_Defaults.lua
+++ b/Options_Defaults.lua
@@ -3270,6 +3270,18 @@ function R:PrepareDefaults()
 			},
 		},
 
+		["Wind-Up Frog"] = {
+			cat = BFA,
+			type = PET,
+			method = USE,
+			name = L["Wind-Up Frog"],
+			spellId = 280617,
+			itemId = 163860,
+			creatureId = 143957,
+			items = { 160324 },
+			chance = 50,
+		},
+
 		-- 8.1 Pets
 
 		["Albatross Feather"] = {

--- a/Options_Defaults.lua
+++ b/Options_Defaults.lua
@@ -3306,6 +3306,18 @@ function R:PrepareDefaults()
 			chance = 50,
 		},
 
+		["Ball of Tentacles"] = {
+			cat = BFA,
+			type = PET,
+			method = USE,
+			name = L["Ball of Tentacles"],
+			spellId = 280619,
+			itemId = 163858,
+			creatureId = 143959,
+			items = { 160324 },
+			chance = 50,
+		},
+
 		-- 8.1 Pets
 
 		["Albatross Feather"] = {

--- a/Options_Defaults.lua
+++ b/Options_Defaults.lua
@@ -2536,6 +2536,18 @@ function R:PrepareDefaults()
 			chance = 10,
 	 },
 
+	 ["Transmutant"] = {
+			cat = LEGION,
+			type = PET,
+			method = USE,
+			name = L["Transmutant"],
+			spellId = 221906,
+			itemId = 139789,
+			creatureId = 111425,
+			items = { 137608 },
+			chance = 10,
+	 },
+
      --["Sting Ray Pup"] =                                 { cat = LEGION, type = PET, method = COLLECTION, name = L["Sting Ray Pup"], spellId = 217218, itemId = 138810, creatureId = 109216, collectedItemId = { 138777 }, chance = 50, },
 					-- 7.1
 	 ["Blessed Seed"] =									 { cat = LEGION, type = PET, method = NPC, name = L["Blessed Seed"], itemId = 142091, spellId = 229098, creatureId = 115143, npcs = { 32906 }, chance = 10, statisticId = {2864, 3258}, doNotUpdateToHighestStat = true,  coords = {{m=148,x=53.2,y=22.3,i=true}},},

--- a/Options_Defaults.lua
+++ b/Options_Defaults.lua
@@ -2511,6 +2511,19 @@ function R:PrepareDefaults()
 					-- 7.0
 	 ["Eye of Inquisition"] =                            { cat = LEGION, type = PET, method = NPC, name = L["Eye of Inquisition"], spellId = 210673, itemId = 136901, npcs = { 101878, }, chance = 100, creatureId = 97179, coords = { {m=680,x=27.8,y=85.2} }},
      ["Knockoff Blingtron"] =                            { cat = LEGION, type = PET, method = USE, name = L["Knockoff Blingtron"], spellId = 210683, itemId = 136911, items = { 132892, 168740 }, chance = 200, creatureId = 99505, },
+
+	 ["Ridgeback Piglet"] = {
+			cat = LEGION,
+			type = PET,
+			method = USE,
+			name = L["Ridgeback Piglet"],
+			spellId = 210678,
+			itemId = 136905,
+			creatureId = 98172,
+			items = { 137608 },
+			chance = 10,
+	 },
+
      --["Sting Ray Pup"] =                                 { cat = LEGION, type = PET, method = COLLECTION, name = L["Sting Ray Pup"], spellId = 217218, itemId = 138810, creatureId = 109216, collectedItemId = { 138777 }, chance = 50, },
 					-- 7.1
 	 ["Blessed Seed"] =									 { cat = LEGION, type = PET, method = NPC, name = L["Blessed Seed"], itemId = 142091, spellId = 229098, creatureId = 115143, npcs = { 32906 }, chance = 10, statisticId = {2864, 3258}, doNotUpdateToHighestStat = true,  coords = {{m=148,x=53.2,y=22.3,i=true}},},


### PR DESCRIPTION
I've added the pets aquired from Alchemy both in Legion and Battle for Azeroth. Both expansions added transmutations to create pets, and a few of those are rare drops with no other source.

Container 1: [Grumbling Sac](https://www.wowhead.com/item=160324/grumbling-sac) from Battle for Azeroth Alchemy: [Transmute: Meat to Pet](https://www.wowhead.com/spell=251808/transmute-meat-to-pet) may contain:
- [Wind-Up Frog](https://www.wowhead.com/item=163860/wind-up-frog)
- [Undulating Blue Sac](https://www.wowhead.com/item=163861/undulating-blue-sac)
- [Ball of Tentacles](https://www.wowhead.com/item=163858/ball-of-tentacles)
- [Baby Crawg](https://www.wowhead.com/item=163859/baby-crawg)

Container 2: [Growling Sac](https://www.wowhead.com/item=137608/growling-sac) from Legion Alchemy: [Transmute: Meat to Pet](https://www.wowhead.com/spell=213256/transmute-meat-to-pet) may contain:
- [Ridgeback Piglet](https://www.wowhead.com/item=136905/ridgeback-piglet)
- [Thaumaturgical Piglet](https://www.wowhead.com/item=136908/thaumaturgical-piglet)
- [Transmutant](https://www.wowhead.com/item=139789/transmutant)