### PR TITLE
DB: Added Battlecry of Krexus

### DIFF
--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -1274,6 +1274,23 @@ function R:OnEvent(event, ...)
 			end
 		end
 
+		-- Handle opening Blackhound Cache (Shadowlands, Maldraxxus cache for Battlecry of Krexus - Necrolord toy)
+		if Rarity.isFishing and Rarity.isOpening and Rarity.lastNode and (Rarity.lastNode == L["Blackhound Cache"]) then
+			local names = {"Battlecry of Krexus"}
+			Rarity:Debug("Detected Opening on " .. L["Blackhound Cache"] .. " (method = SPECIAL)")
+			for _, name in pairs(names) do
+				local v = self.db.profile.groups.items[name] or self.db.profile.groups.pets[name]
+				if v and type(v) == "table" and v.enabled ~= false then
+					if v.attempts == nil then
+						v.attempts = 1
+					else
+						v.attempts = v.attempts + 1
+					end
+					self:OutputAttempts(v)
+				end
+			end
+		end
+
 		-- Handle opening Pile of Coins
 		if Rarity.isFishing and Rarity.isOpening and Rarity.lastNode and (Rarity.lastNode == L["Pile of Coins"]) then
 			local names = {"Armored Vaultbot"}

--- a/DB/Nodes.lua
+++ b/DB/Nodes.lua
@@ -225,5 +225,6 @@ R.opennodes = {
 	[L["Slime-Coated Crate"]] = true,
 	[L["Sprouting Growth"]] = true,
 	[L["Stewart's Stewpendous Stew"]] = true,
-	[L["Bleakwood Chest"]] = true
+	[L["Bleakwood Chest"]] = true,
+	[L["Blackhound Cache"]] = true
 }

--- a/Locales.lua
+++ b/Locales.lua
@@ -1638,6 +1638,8 @@ L["Ball of Tentacles"] = true
 L["Ridgeback Piglet"] = true
 L["Thaumaturgical Piglet"] = true
 L["Transmutant"] = true
+L["Battlecry of Krexus"] = true
+L["Blackhound Cache"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Options_Defaults.lua
+++ b/Options_Defaults.lua
@@ -7245,6 +7245,21 @@ function R:PrepareDefaults()
 		},
 	},
 
+	["Battlecry of Krexus"] = {
+		cat = SHADOWLANDS,
+		type = ITEM,
+		isToy = true,
+		method = SPECIAL,
+		name = L["Battlecry of Krexus"],
+		itemId = 184318,
+		items = { 352086, },
+		chance = 25,
+		sourceText = L["Only members of the Necrolord covenant will be able to reach this cache."],
+		coords = {
+			{ m = CONSTANTS.UIMAPIDS.MALDRAXXUS, x = 44.1, y = 40.0, n = L["Blackhound Cache"] },
+		},
+	},
+
 
 	-- ["AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"] = {
 	-- 	cat = BFA,


### PR DESCRIPTION
Added the 9.0 toy [Battlecry of Krexus](https://www.wowhead.com/item=184318/battlecry-of-krexus). This toy can be looted from a [chest](https://www.wowhead.com/object=352086/blackhound-cache) in Maldraxxus. This is practically a Necrolord only toy, but I have not implemented the covenant restrictions on the item, given that Blizzard has mechanics preventing other covenants to reach this chest in the first place. There are reports of other covenants gaining access to this chest and thus having looted the toy, but this seems to have been hotfixed.