### PR TITLE
DB: Added Larion Pouncer (pet)

### DIFF
--- a/Locales.lua
+++ b/Locales.lua
@@ -1640,6 +1640,8 @@ L["Thaumaturgical Piglet"] = true
 L["Transmutant"] = true
 L["Battlecry of Krexus"] = true
 L["Blackhound Cache"] = true
+L["Larion Pouncer"] = true
+L["Larionrider Orstus"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Options_Defaults.lua
+++ b/Options_Defaults.lua
@@ -5949,6 +5949,22 @@ function R:PrepareDefaults()
 		},
 	},
 
+	["Larion Pouncer"] = {
+		cat = SHADOWLANDS,
+		type = PET,
+		method = NPC,
+		name = L["Larion Pouncer"],
+		itemId = 184401,
+		spellId = 345742,
+		creatureId = 175562,
+		npcs = { 156340 },
+		questId = 61634,
+		chance = 25,
+		coords = {
+			{ m = CONSTANTS.UIMAPIDS.BASTION, x = 22.6, y = 22.8, n = L["Larionrider Orstus"] },
+		},
+	},
+
 },
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 				-- TOYS AND ITEMS


### PR DESCRIPTION
Added another pet from 9.0 - this time the [Larion Pouncer](https://www.wowhead.com/item=184401/larion-pouncer) from a rare in Bastion which spawns from Anima Conductor rank 3. There is not enough data to tell if this is a Kryian covenant only drop, so I haven't flagged it as a requirement. Will just have to keep an eye on it.