### PR TITLE
DB: Added Soullocked Sinstone (pet)

### DIFF
--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -1291,6 +1291,23 @@ function R:OnEvent(event, ...)
 			end
 		end
 
+		-- Handle opening Secret Treasure (Shadowlands, Revendreth chest for Soullocked Sinstone pet)
+		if Rarity.isFishing and Rarity.isOpening and Rarity.lastNode and (Rarity.lastNode == L["Secret Treasure"]) then
+			local names = {"Soullocked Sinstone"}
+			Rarity:Debug("Detected Opening on " .. L["Secret Treasure"] .. " (method = SPECIAL)")
+			for _, name in pairs(names) do
+				local v = self.db.profile.groups.items[name] or self.db.profile.groups.pets[name]
+				if v and type(v) == "table" and v.enabled ~= false then
+					if v.attempts == nil then
+						v.attempts = 1
+					else
+						v.attempts = v.attempts + 1
+					end
+					self:OutputAttempts(v)
+				end
+			end
+		end
+
 		-- Handle opening Pile of Coins
 		if Rarity.isFishing and Rarity.isOpening and Rarity.lastNode and (Rarity.lastNode == L["Pile of Coins"]) then
 			local names = {"Armored Vaultbot"}

--- a/DB/Nodes.lua
+++ b/DB/Nodes.lua
@@ -226,5 +226,6 @@ R.opennodes = {
 	[L["Sprouting Growth"]] = true,
 	[L["Stewart's Stewpendous Stew"]] = true,
 	[L["Bleakwood Chest"]] = true,
-	[L["Blackhound Cache"]] = true
+	[L["Blackhound Cache"]] = true,
+	[L["Secret Treasure"]] = true
 }

--- a/Locales.lua
+++ b/Locales.lua
@@ -1642,6 +1642,8 @@ L["Battlecry of Krexus"] = true
 L["Blackhound Cache"] = true
 L["Larion Pouncer"] = true
 L["Larionrider Orstus"] = true
+L["Soullocked Sinstone"] = true
+L["Secret Treasure"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Options_Defaults.lua
+++ b/Options_Defaults.lua
@@ -5965,6 +5965,20 @@ function R:PrepareDefaults()
 		},
 	},
 
+	["Soullocked Sinstone"] = {
+		cat = SHADOWLANDS,
+		type = PET,
+		method = SPECIAL,
+		name = L["Soullocked Sinstone"],
+		itemId = 180589,
+		spellId = 333800,
+		creatureId = 171122,
+		chance = 20,
+		coords = {
+			{ m = CONSTANTS.UIMAPIDS.REVENDRETH },
+		},
+	},
+
 },
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 				-- TOYS AND ITEMS


### PR DESCRIPTION
Added the pet [Soullocked Sinstone](https://www.wowhead.com/item=180589/soullocked-sinstone#contained-in-object) from a chest in Revendreth. Chest has multiple spawn locations, hence the lack of coordinates. Not much recorded data on it yet, but I have confirmed the pet on the AH, so it is obtainable, allthough the drop rate is a blind guess from the current data.