### PR TITLE
DB: Added Silessa's Battle Harness

### DIFF
--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -1308,6 +1308,23 @@ function R:OnEvent(event, ...)
 			end
 		end
 
+		-- Handle opening Forgotten Chest (Venthyr only chest for Silessa's Battle Harness in Revendreth, Shadowlands)
+		if Rarity.isFishing and Rarity.isOpening and Rarity.lastNode and (Rarity.lastNode == L["Forgotten Chest"]) then
+			local names = {"Silessa's Battle Harness"}
+			Rarity:Debug("Detected Opening on " .. L["Forgotten Chest"] .. " (method = SPECIAL)")
+			for _, name in pairs(names) do
+				local v = self.db.profile.groups.items[name] or self.db.profile.groups.mounts[name]
+				if v and type(v) == "table" and v.enabled ~= false then
+					if v.attempts == nil then
+						v.attempts = 1
+					else
+						v.attempts = v.attempts + 1
+					end
+					self:OutputAttempts(v)
+				end
+			end
+		end
+
 		-- Handle opening Pile of Coins
 		if Rarity.isFishing and Rarity.isOpening and Rarity.lastNode and (Rarity.lastNode == L["Pile of Coins"]) then
 			local names = {"Armored Vaultbot"}

--- a/DB/Nodes.lua
+++ b/DB/Nodes.lua
@@ -227,5 +227,6 @@ R.opennodes = {
 	[L["Stewart's Stewpendous Stew"]] = true,
 	[L["Bleakwood Chest"]] = true,
 	[L["Blackhound Cache"]] = true,
-	[L["Secret Treasure"]] = true
+	[L["Secret Treasure"]] = true,
+	[L["Forgotten Chest"]] = true
 }

--- a/Locales.lua
+++ b/Locales.lua
@@ -1645,6 +1645,8 @@ L["Larion Pouncer"] = true
 L["Larionrider Orstus"] = true
 L["Soullocked Sinstone"] = true
 L["Secret Treasure"] = true
+L["Silessa's Battle Harness"] = true
+L["Forgotten Chest"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Options_Defaults.lua
+++ b/Options_Defaults.lua
@@ -1590,6 +1590,19 @@ function R:PrepareDefaults()
 			},
 		},
 
+		["Silessa's Battle Harness"] = {
+			cat = SHADOWLANDS,
+			type = MOUNT,
+			method = SPECIAL,
+			name = L["Silessa's Battle Harness"],
+			spellId = 333023,
+			itemId = 183798,
+			chance = 100,
+			coords = {
+				{ m = CONSTANTS.UIMAPIDS.REVENDRETH }
+			},
+		},
+
 
 
 	--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Added the 9.0 mount [Silessa's Battle Harness](https://www.wowhead.com/item=183798/silessas-battle-harness). This mount can be obtained from a chest within the Broken Mirrors (Venthyr Travel Network rank 3).