### PR TITLE
DB: Added Luminous Webspinner (pet)

### DIFF
--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -1325,6 +1325,23 @@ function R:OnEvent(event, ...)
 			end
 		end
 
+		-- Handle opening Cache of Eyes (Shadowlands, Maldraxxus chest for Luminous Webspinner pet)
+		if Rarity.isFishing and Rarity.isOpening and Rarity.lastNode and (Rarity.lastNode == L["Cache of Eyes"]) then
+			local names = {"Luminous Webspinner"}
+			Rarity:Debug("Detected Opening on " .. L["Cache of Eyes"] .. " (method = SPECIAL)")
+			for _, name in pairs(names) do
+				local v = self.db.profile.groups.items[name] or self.db.profile.groups.pets[name]
+				if v and type(v) == "table" and v.enabled ~= false then
+					if v.attempts == nil then
+						v.attempts = 1
+					else
+						v.attempts = v.attempts + 1
+					end
+					self:OutputAttempts(v)
+				end
+			end
+		end
+
 		-- Handle opening Pile of Coins
 		if Rarity.isFishing and Rarity.isOpening and Rarity.lastNode and (Rarity.lastNode == L["Pile of Coins"]) then
 			local names = {"Armored Vaultbot"}

--- a/DB/Nodes.lua
+++ b/DB/Nodes.lua
@@ -228,5 +228,6 @@ R.opennodes = {
 	[L["Bleakwood Chest"]] = true,
 	[L["Blackhound Cache"]] = true,
 	[L["Secret Treasure"]] = true,
-	[L["Forgotten Chest"]] = true
+	[L["Forgotten Chest"]] = true,
+	[L["Cache of Eyes"]] = true
 }

--- a/Locales.lua
+++ b/Locales.lua
@@ -1647,6 +1647,8 @@ L["Soullocked Sinstone"] = true
 L["Secret Treasure"] = true
 L["Silessa's Battle Harness"] = true
 L["Forgotten Chest"] = true
+L["Luminous Webspinner"] = true
+L["Cache of Eyes"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Options_Defaults.lua
+++ b/Options_Defaults.lua
@@ -5992,6 +5992,20 @@ function R:PrepareDefaults()
 		},
 	},
 
+	["Luminous Webspinner"] = {
+		cat = SHADOWLANDS,
+		type = PET,
+		method = SPECIAL,
+		name = L["Luminous Webspinner"],
+		itemId = 181171,
+		spellId = 335762,
+		creatureId = 171985,
+		chance = 25, -- Blind guess
+		coords = {
+			{ m = CONSTANTS.UIMAPIDS.MALDRAXXUS },
+		},
+	},
+
 },
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 				-- TOYS AND ITEMS


### PR DESCRIPTION
Added yet another missing pet from 9.0. [Luminous Webspinner](https://www.wowhead.com/item=181171/luminous-webspinner) from a cache in Maldraxxus. No clue on the drop rate. I got it first attempt, but reports on wowhead says it's not 100%