### PR TITLE
DB: Added Stony's Infused Ruby (pet)

### DIFF
--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -1340,6 +1340,23 @@ function R:OnEvent(event, ...)
 			end
 		end
 
+		-- Handle opening Forgotten Chest (Venthyr only chest for Stony's Infused Ruby pet in Revendreth, Shadowlands)
+		if Rarity.isFishing and Rarity.isOpening and Rarity.lastNode and (Rarity.lastNode == L["Forgotten Chest"]) then
+			local names = {"Stony's Infused Ruby"}
+			Rarity:Debug("Detected Opening on " .. L["Forgotten Chest"] .. " (method = SPECIAL)")
+			for _, name in pairs(names) do
+				local v = self.db.profile.groups.items[name] or self.db.profile.groups.pets[name]
+				if v and type(v) == "table" and v.enabled ~= false then
+					if v.attempts == nil then
+						v.attempts = 1
+					else
+						v.attempts = v.attempts + 1
+					end
+					self:OutputAttempts(v)
+				end
+			end
+		end
+
 		-- Handle opening Pile of Coins
 		if Rarity.isFishing and Rarity.isOpening and Rarity.lastNode and (Rarity.lastNode == L["Pile of Coins"]) then
 			local names = {"Armored Vaultbot"}

--- a/DB/Nodes.lua
+++ b/DB/Nodes.lua
@@ -240,5 +240,6 @@ R.opennodes = {
 	[L["Blackhound Cache"]] = true,
 	[L["Secret Treasure"]] = true,
 	[L["Forgotten Chest"]] = true,
-	[L["Cache of Eyes"]] = true
+	[L["Cache of Eyes"]] = true,
+	[L["Forgotten Chest"]] = true
 }

--- a/Locales.lua
+++ b/Locales.lua
@@ -1659,6 +1659,8 @@ L["Silessa's Battle Harness"] = true
 L["Forgotten Chest"] = true
 L["Luminous Webspinner"] = true
 L["Cache of Eyes"] = true
+L["Stony's Infused Ruby"] = true
+L["Forgotten Chest"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Options_Defaults.lua
+++ b/Options_Defaults.lua
@@ -6006,6 +6006,20 @@ function R:PrepareDefaults()
 		},
 	},
 
+	["Stony's Infused Ruby"] = {
+		cat = SHADOWLANDS,
+		type = PET,
+		method = SPECIAL,
+		name = L["Stony's Infused Ruby"],
+		itemId = 183855,
+		spellId = 339674,
+		creatureId = 173536,
+		chance = 100, -- Estimate
+		coords = {
+			{ m = CONSTANTS.UIMAPIDS.REVENDRETH },
+		},
+	},
+
 },
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 				-- TOYS AND ITEMS


### PR DESCRIPTION
Added another missing Shadowlands pet. [Stony's Infused Ruby](https://www.wowhead.com/item=183855/stonys-infused-ruby) from the Venthyr broken mirror system. Haven't personally been able to test this, as I don't have a venthyr, but seems pretty straight forward. 