### PR TITLE
DB: Added achievement tooltip for Mechagon/Nazjatar rares. Closes #122

### DIFF
--- a/Options_Defaults.lua
+++ b/Options_Defaults.lua
@@ -278,6 +278,8 @@ function R:PrepareDefaults()
 				12942, -- Adventurer of Nazmir
 				12943, -- Adventurer of Vol'dun
 				12944, -- Adventurer of Zuldazar
+				13691, -- I Thought You Said They'd Be Rare? (Nazjatar)
+				13470, -- Rest In Pistons (Mechagon)
 
 			},
 


### PR DESCRIPTION
Added the achievement tooltips for [Mechagon](https://www.wowhead.com/achievement=13470/rest-in-pistons) and [Nazjatar](https://www.wowhead.com/achievement=13691/i-thought-you-said-theyd-be-rare) rares. As far as I can tell, this as all that's needed for this to function. Should in that case close #122