### PR TITLE
DB: Fixed Mechagon dungeon pets. This resolves #170

### DIFF
--- a/Options_Defaults.lua
+++ b/Options_Defaults.lua
@@ -4824,7 +4824,7 @@ function R:PrepareDefaults()
 		cat = BFA,
 		type = PET,
 		method = NPC,
-		npcs = { 150190, 155157 },
+		npcs = { 150190 },
 		name = L["Microbot 8D"],
 		spellId = 301056,
 		itemId = 169385,
@@ -4832,6 +4832,19 @@ function R:PrepareDefaults()
 		chance = 55,
 		groupSize = 5,
 		equalOdds = true,
+		instanceDifficulties = { [CONSTANTS.INSTANCE_DIFFICULTIES.MYTHIC_DUNGEON] = true },
+		lockoutDetails = {
+			mode = CONSTANTS.DEFEAT_DETECTION.MODE_AND,
+			{
+				encounterName = "HK-8 Aerial Oppression Unit",
+				instanceDifficulties = {
+					[CONSTANTS.INSTANCE_DIFFICULTIES.MYTHIC_DUNGEON] = true,
+				},
+			},
+		},
+		coords = {
+			{ m = CONSTANTS.UIMAPIDS.MECHAGON_ISLAND_DUNGEON, i = true}
+		},
 	},
 
 	["Golden Snorf"] = {

--- a/Options_Defaults.lua
+++ b/Options_Defaults.lua
@@ -4851,9 +4851,9 @@ function R:PrepareDefaults()
 		cat = BFA,
 		type = PET,
 		method = NPC,
-		npcs = { 99999 },
-		tooltipNpcs = { 150397, 154817 },
-		statisticId = { 14056, 13620 },
+		npcs = { 150397 },
+		tooltipNpcs = { 150396, 144249 },
+		statisticId = { 13620 },
 		name = L["Golden Snorf"],
 		spellId = 301049,
 		itemId = 169378,
@@ -4861,6 +4861,19 @@ function R:PrepareDefaults()
 		chance = 65,
 		groupSize = 5,
 		equalOdds = true,
+		instanceDifficulties = { [CONSTANTS.INSTANCE_DIFFICULTIES.MYTHIC_DUNGEON] = true },
+		lockoutDetails = {
+			mode = CONSTANTS.DEFEAT_DETECTION.MODE_AND,
+			{
+				encounterName = "King Mechagon",
+				instanceDifficulties = {
+					[CONSTANTS.INSTANCE_DIFFICULTIES.MYTHIC_DUNGEON] = true,
+				},
+			},
+		},
+		coords = {
+			{ m = CONSTANTS.UIMAPIDS.MECHAGON_ISLAND_DUNGEON, i = true}
+		},
 	},
 
 	-- 8.3 Pets


### PR DESCRIPTION
Fixed attempts tracking for [Microbot 8D](https://www.wowhead.com/item=169385/microbot-8d) and [Golden Snorf](https://www.wowhead.com/item=169378/golden-snorf). These were being tracked in both heroic and mythic, but only drops in mythic mode. Also added UiMapIDs for both and added defeat detection. This also resloves #170 since this dungeon is no longer available in mythic keystone.