### PR TITLE
DB: Added Bottle of Gloop. This closes #158

### DIFF
--- a/DB/Nodes.lua
+++ b/DB/Nodes.lua
@@ -143,6 +143,8 @@ R.fishnodes = {
 	[L["Viper Fish School"]] = true,
 	[L["Ionized Minnows"]] = true,
 	[L["Sentry Fish School"]] = true,
+	[L["Aberrant Voidfin School"]] = true,
+	[L["Malformed Gnasher School"]] = true,
 	-- Shadowlands pools
 	[L["Iridescent Amberjack School"]] = true,
 	[L["Pocked Bonefish School"]] = true,

--- a/Locales.lua
+++ b/Locales.lua
@@ -1664,6 +1664,7 @@ L["Cache of Eyes"] = true
 L["Stony's Infused Ruby"] = true
 L["Forgotten Chest"] = true
 L["Smoldering Ember Wyrm"] = true
+L["Bottle of Gloop"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Locales.lua
+++ b/Locales.lua
@@ -1002,6 +1002,8 @@ L["Silvergill Pike School"] = true
 L["Elysian Thade School"] = true
 L["Lost Sole School"] = true
 L["Spinefin Piranha School"] = true
+L["Aberrant Voidfin School"] = true
+L["Malformed Gnasher School"] = true
 
 -- Mining nodes
 L["Copper Vein"] = true

--- a/Options_Defaults.lua
+++ b/Options_Defaults.lua
@@ -5422,6 +5422,23 @@ function R:PrepareDefaults()
 		},
 	},
 
+	["Bottle of Gloop"] = {
+		cat = BFA,
+		type = PET,
+		method = FISHING,
+		name = L["Bottle of Gloop"],
+		zones = { tostring(CONSTANTS.UIMAPIDS.ULDUM), tostring(CONSTANTS.UIMAPIDS.VALE_OF_ETERNAL_BLOSSOMS) },
+		spellId = 315285,
+		itemId = 174456,
+		creatureId = 161951,
+		chance = 500,
+		requiresPool = true,
+		coords = {
+			{ m = CONSTANTS.UIMAPIDS.ULDUM },
+			{ m = CONSTANTS.UIMAPIDS.VALE_OF_ETERNAL_BLOSSOMS },
+		},
+	},
+
 	["Strand Crawler"] = {
 		-- Note: Also drops from the Northrend fishing bag (but Rarity can't track items from two different sources...)
 		cat = WOD,


### PR DESCRIPTION
Added the pet [Bottle of Gloop](https://www.wowhead.com/item=174456/bottle-of-gloop) which is obtained from fishing in BfA. This pet can only drop from fishing pools (Aberrant Voidfin School & Malformed Gnasher School) in the corrupted version of Uldum and Vale of Eternal Blossom. Both these two zones have different mapID's than the normal ones, and it appears that only these two types of fishing pools are available in these corrupted zones - thus making the tracking a lot easier than first thought. In sum: tracking that fishing is done in a pool in these two zones is enough.

This should close #158.