### PR TITLE
GUI: Added NPC ID to tooltip if debug mode is enabled.

### DIFF
--- a/Core/GUI.lua
+++ b/Core/GUI.lua
@@ -1905,6 +1905,11 @@ end
 _G.GameTooltip:HookScript(
 	"OnTooltipSetUnit",
 	function(self)
+		-- If debug mode is on, find NPCID from mouseover target and append it to the tooltip
+		if R.db.profile.debugMode then
+			GameTooltip:AddLine("NPCID: " .. R:GetNPCIDFromGUID(UnitGUID("mouseover")), 255, 255, 255)
+		end
+
 		if not R.db or R.db.profile.enableTooltipAdditions == false then
 			return
 		end


### PR DESCRIPTION
Added NPC ID to tooltip if debug mode is enabled. This closes #99
This will ignore the setting to disable tooltip additions, I figured that made more sense.

[https://imgur.com/a/NmJ4eTO](https://imgur.com/a/NmJ4eTO)