### PR TITLE
Made achievement toasts unclickable.

### DIFF
--- a/Core/GUI.lua
+++ b/Core/GUI.lua
@@ -2631,6 +2631,7 @@ local function RarityAchievementAlertFrame_SetUp(frame, itemId, attempts)
 	shieldIcon:SetTexture([[Interface\AchievementFrame\UI-Achievement-Shields-NoPoints]])
 
 	frame.Icon.Texture:SetTexture(itemTexture)
+	frame:EnableMouse(false)	-- Make achievement toast unclickable
 
 	if attempts == nil or attempts <= 0 then
 		attempts = 1
@@ -2648,6 +2649,7 @@ local function RarityAchievementAlertFrame_SetUp(frame, itemId, attempts)
 		function()
 			-- Put the achievement frame back to normal when we're done
 			unlocked:SetText(ACHIEVEMENT_UNLOCKED)
+			frame:EnableMouse(true)
 		end,
 		10
 	)


### PR DESCRIPTION
There is really no idea as far as I can tell as to why these should be clickable in the first place. The original Blizzard achievements open the Achievement frame and shows the new addition there, but these bogus toasts have no ties to that frame. As per now they either result in LUA erros or show a broken achievement frame. This should resolve #26.