### PR TITLE
Tooltip configurable delay

### DIFF
--- a/Core/GUI.lua
+++ b/Core/GUI.lua
@@ -13,6 +13,7 @@ scanTip:SetOwner(WorldFrame, "ANCHOR_NONE")
 GUI.scanTip = scanTip
 local numHolidayReminders = 0
 local showedHolidayReminderOverflow = false
+local tooltipOpenDelay = false
 
 -- Externals
 local L = LibStub("AceLocale-3.0"):GetLocale("Rarity")
@@ -407,13 +408,21 @@ end
 function dataobj.OnEnter(self)
 	frame = self
 	if Rarity.db.profile.tooltipActivation == CONSTANTS.TOOLTIP.ACTIVATION_METHOD_HOVER then
-		Rarity:ShowTooltip()
+		tooltipOpenDelay = true
+		-- The following will queue opening of the tooltip based on a user set delay that triggers on mouseover.
+		C_Timer.After(
+			Rarity.db.profile.tooltipShowDelay or 0.1, -- Delay in seconds
+			function()
+				Rarity:ShowDelayedTooltip()
+			end
+		)
 	else
 		Rarity:ShowQuicktip()
 	end
 end
 
 function dataobj.OnLeave(self)
+	tooltipOpenDelay = false	-- Set false to abort any pending Tooltip openings that is called in ShowDelayedTooltip()
 end
 
 function dataobj:OnClick(button)
@@ -1591,6 +1600,13 @@ local function addGroup(group, requiresGroup)
 end
 
 local renderingQuicktip = false
+
+-- Helper function to open the Tooltip GUI unless the delayed opening has been aborted meanwhile.
+function R:ShowDelayedTooltip()
+	if tooltipOpenDelay == true then
+		Rarity:ShowTooltip()
+	end
+end
 
 function R:HideQuicktip()
 	if quicktip and quicktip:IsVisible() then

--- a/Locales.lua
+++ b/Locales.lua
@@ -861,6 +861,8 @@ L[
 	] = true
 L["When on, Rarity will generate an achievement alert pop-up indicating that you obtained an item."] = true
 L["Show achievement"] = true
+L["Primary tooltip show delay"] = true
+L["When you move your mouse over the Rarity minimap icon, it will take this long before the GUI opens."] = true
 
 -- Sources
 -- L[""] = true -> This seems pointless and breaks the import feature on WowAce, therefore I disabled it. I left it here because I really don't understand why it has been added and kept around for almost 4 years, so...eh ¯\_(ツ)_/¯

--- a/Modules/Options/Options.lua
+++ b/Modules/Options/Options.lua
@@ -689,7 +689,21 @@ function R:PrepareOptions()
 									self:Update("OPTIONS")
 								end,
 								order = newOrder()
-							} -- statusTip
+							}, -- statusTip
+							tooltipShowDelay = {
+								order = newOrder(),
+								type = "range",
+				 				width = "double",
+								name = L["Primary tooltip show delay"],
+								desc = L["When you move your mouse over the Rarity minimap icon, it will take this long before the GUI opens."],
+								min = 0,
+								max = 5,
+								step = .1,
+								get = function() return self.db.profile.tooltipShowDelay or 0.1 end,
+								set = function(_, val)
+				  				self.db.profile.tooltipShowDelay = val
+								end,
+							}
 						} -- args
 					}, -- rarityTooltip
 					worldTooltips = {

--- a/Options_Defaults.lua
+++ b/Options_Defaults.lua
@@ -94,6 +94,7 @@ function R:PrepareDefaults()
 			blankLineAfterRarity = false,
 			hideOutsideZone = false,
 			showAchievementToast = true,
+			tooltipShowDelay = 0.1,
 
 			trackedGroup = "pets",
 			trackedItem = 8494,


### PR DESCRIPTION
Added functionality to configure and delay opening of the main tooltip. The option settings function just like the one to delay closing of the tooltip, but the logic to delay the opening is done with a call to Blizzard's function instead, as LibQTip don't support that.
This is bundled with the mouseover event, and has a default delay of 0.1 seconds.
This resolves #7.