### PR TITLE
DB: Added Lucy's Lost Collar

### DIFF
--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -141,6 +141,12 @@ function R:OnSpellcastSucceeded(event, unitID, castGUID, spellID)
 		self:Debug("Finished searching mailbox in a Horrific Vision")
 		addAttemptForItem("Mail Muncher", "mounts")
 	end
+
+	-- Detects opening on Dirty Glinting Object which may contain Lucy's Lost Collar
+	if spellID == 345071 and Rarity.lastNode and Rarity.lastNode == L["Dirty Glinting Object"] then
+		Rarity:Debug("Detected Opening on " .. L["Dirty Glinting Object"] .. " (method = SPECIAL)")
+		addAttemptForItem("Lucy's Lost Collar", "pets")
+	end
 end
 
 -------------------------------------------------------------------------------------

--- a/DB/Items/Pets/Shadowlands.lua
+++ b/DB/Items/Pets/Shadowlands.lua
@@ -620,6 +620,23 @@ local shadowlandsPets = {
 		coords = {
 			{m = CONSTANTS.UIMAPIDS.REVENDRETH}
 		}
+	},
+	["Lucy's Lost Collar"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.SHADOWLANDS,
+		type = CONSTANTS.ITEM_TYPES.PET,
+		method = CONSTANTS.DETECTION_METHODS.SPECIAL,
+		name = L["Lucy's Lost Collar"],
+		itemId = 184507,
+		spellId = 346192,
+		creatureId = 175715,
+		npcs = {175390},
+		chance = 100, -- Estimate
+		coords = {
+			{m = CONSTANTS.UIMAPIDS.BASTION},
+			{m = CONSTANTS.UIMAPIDS.ARDENWEALD},
+			{m = CONSTANTS.UIMAPIDS.REVENDRETH},
+			{m = CONSTANTS.UIMAPIDS.MALDRAXXUS}
+		}
 	}
 }
 

--- a/DB/Nodes.lua
+++ b/DB/Nodes.lua
@@ -242,5 +242,6 @@ R.opennodes = {
 	[L["Secret Treasure"]] = true,
 	[L["Forgotten Chest"]] = true,
 	[L["Cache of Eyes"]] = true,
-	[L["Forgotten Chest"]] = true
+	[L["Forgotten Chest"]] = true,
+	[L["Dirty Glinting Object"]] = true
 }

--- a/DB/Spells.lua
+++ b/DB/Spells.lua
@@ -20,6 +20,8 @@ Rarity.relevantSpells = {
 	[6478] = "Opening", -- Pile of Coins (Mechagon Island: Armored Vaultbot)
 	-- 8.3
 	[312881] = "Searching Mailbox",
+	-- 9.0
+	[345071] = "Looting", -- Dirty Glinting Object (Shadowlands zones for Lucy's Lost Collar pet)
 	-- Not tested (but added just in case)
 	[7731] = "Fishing",
 	[7732] = "Fishing",

--- a/Locales.lua
+++ b/Locales.lua
@@ -1790,6 +1790,8 @@ L["Forgotten Chest"] = true
 L["Smoldering Ember Wyrm"] = true
 L["Bottle of Gloop"] = true
 L["Piccolo of the Flaming Fire"] = true
+L["Lucy's Lost Collar"] = true
+L["Dirty Glinting Object"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.


### PR DESCRIPTION
Added tracking for Lucy's Lost Collar. This was a minor headache, because allthough the Dirty Glinting Object is registered as an NPC, the looting is different from any normal NPC. It uses a different opening spell (called "Looting") and it isn't cought by the normal methods. 

I had to add this as a special case. Rarity.isOpening is hardcoded to only accept spells translated to "Opening" and I didn't want to fake name this spell or expand those just to get past the checks. Detection is therefor similar to the one used for Mail Muncher in Horrific Visions. 

This closes #276.