### PR TITLE
Core: Made faction restriction colors more intuitive

### DIFF
--- a/Core/Caching.lua
+++ b/Core/Caching.lua
@@ -22,6 +22,18 @@ function Caching:IsHorde()
 	return Rarity.isHorde
 end
 
+function Caching:IsAlliance()
+	if Rarity.isAlliance == nil then
+		local englishFaction, localizedFaction = UnitFactionGroup("player")
+		if englishFaction == "Alliance" then
+			Rarity.isAlliance = true
+		else
+			Rarity.isAlliance = false
+		end
+	end
+	return Rarity.isAlliance
+end
+
 function Caching:IsReady()
 	return not IsInitializing
 end

--- a/Core/GUI.lua
+++ b/Core/GUI.lua
@@ -679,7 +679,7 @@ local function showSubTooltip(cell, item)
 		tooltip2AddLine(colorize(L["Can be obtained with a bonus roll"], yellow))
 	end
 	if item.requiresAlliance then
-		tooltip2AddLine(colorize(L["This mount is only obtainable by Alliance players"], not R.Caching:IsHorde() and green or red))
+		tooltip2AddLine(colorize(L["This mount is only obtainable by Alliance players"], R.Caching:IsAlliance() and green or red))
 	end
 	if item.requiresHorde then
 		tooltip2AddLine(colorize(L["This mount is only obtainable by Horde players"], R.Caching:IsHorde() and green or red))

--- a/Core/GUI.lua
+++ b/Core/GUI.lua
@@ -679,10 +679,10 @@ local function showSubTooltip(cell, item)
 		tooltip2AddLine(colorize(L["Can be obtained with a bonus roll"], yellow))
 	end
 	if item.requiresAlliance then
-		tooltip2AddLine(colorize(L["This mount is only obtainable by Alliance players"], red))
+		tooltip2AddLine(colorize(L["This mount is only obtainable by Alliance players"], not R.Caching:IsHorde() and green or red))
 	end
 	if item.requiresHorde then
-		tooltip2AddLine(colorize(L["This mount is only obtainable by Horde players"], red))
+		tooltip2AddLine(colorize(L["This mount is only obtainable by Horde players"], R.Caching:IsHorde() and green or red))
 	end
 	if
 		hadSource or item.bonusSatchel or item.blackMarket or item.wasGuaranteed or item.worldBossFactionless or

--- a/Modules/Options/Options.lua
+++ b/Modules/Options/Options.lua
@@ -1825,13 +1825,13 @@ function R:CreateGroup(options, group, isUser)
 				requiresAllianceT = {
 					type = "description",
 					order = newOrder(),
-					name = colorize(L["This mount is only obtainable by Alliance players"], red),
+					name = colorize(L["This mount is only obtainable by Alliance players"], not R.Caching:IsHorde() and green or red),
 					hidden = item.requiresAlliance == false or item.requiresAlliance == nil
 				},
 				requiresHordeT = {
 					type = "description",
 					order = newOrder(),
-					name = colorize(L["This mount is only obtainable by Horde players"], red),
+					name = colorize(L["This mount is only obtainable by Horde players"], R.Caching:IsHorde() and green or red),
 					hidden = item.requiresHorde == false or item.requiresHorde == nil
 				},
 				blankLine = {

--- a/Modules/Options/Options.lua
+++ b/Modules/Options/Options.lua
@@ -1825,7 +1825,7 @@ function R:CreateGroup(options, group, isUser)
 				requiresAllianceT = {
 					type = "description",
 					order = newOrder(),
-					name = colorize(L["This mount is only obtainable by Alliance players"], not R.Caching:IsHorde() and green or red),
+					name = colorize(L["This mount is only obtainable by Alliance players"], R.Caching:IsAlliance() and green or red),
 					hidden = item.requiresAlliance == false or item.requiresAlliance == nil
 				},
 				requiresHordeT = {


### PR DESCRIPTION
Make a quick fix which should close #304. This makes the notification green if you are on the right faction and stays red when you are not. Found these in the main GUI as well as in the Options. Don't think these show up as NPC tooltips?