### PR TITLE
Strip the colour code from tooltip strings

### DIFF
--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -835,6 +835,13 @@ end
 
 local tooltipLeftText1 = _G["GameTooltipTextLeft1"]
 
+local function stripColorCode(input)
+	local output = input or ""
+	output = gsub(output, "|c%x%x%x%x%x%x%x%x", "")
+	output = gsub(output, "|r", "")
+	return output
+end
+
 function R:OnCursorUpdate(event)
 	if Rarity.foundTarget then
 		return
@@ -842,7 +849,7 @@ function R:OnCursorUpdate(event)
 	if (MinimapCluster:IsMouseOver()) then
 		return
 	end
-	local t = tooltipLeftText1:GetText()
+	local t = stripColorCode(tooltipLeftText1:GetText())
 	if self.miningnodes[t] or self.fishnodes[t] or self.opennodes[t] then
 		Rarity.lastNode = t
 		Rarity:Debug("OnCursorUpdate found lastNode = " .. tostring(t))


### PR DESCRIPTION
This is not usually a problem, as most nodes are not colour coded (although I am not sure if any addons do modify this?).

However, with the addition of the Dirty Glinting Object, this produces an NPC tooltip. For some users, this will be colour coded and therefore it will not properly detect the attempt on Lucy's Lost Collar.

The colour coding will now be stripped if it does exist.

----------------

I'm not happy with where I placed the `StripColourCode` function? Any ideas for a more appropriate place?

Sorry if I haven't made myself clear in the commit/pull request message. I'll try to explain it a bit more if so.