### PR TITLE
Forgotten Chest has a namesake in Stormsong Valley that should be ignored

### DIFF
--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -1326,7 +1326,9 @@ function R:OnEvent(event, ...)
 		end
 
 		-- Handle opening Forgotten Chest (Shadowlands, Revendreth chest for Stony's Infused Ruby pet and Silessa's Battle Harness mount)
-		if Rarity.isFishing and Rarity.isOpening and Rarity.lastNode and (Rarity.lastNode == L["Forgotten Chest"]) then
+		if Rarity.isFishing and Rarity.isOpening and Rarity.lastNode and (Rarity.lastNode == L["Forgotten Chest"])
+			and GetBestMapForUnit("player") ~= CONSTANTS.UIMAPIDS.STORMSONG_VALLEY -- Chest with the same name in Stormsong Valley
+		then
 			local names = {"Stony's Infused Ruby", "Silessa's Battle Harness"}
 			Rarity:Debug("Detected Opening on " .. L["Forgotten Chest"] .. " (method = SPECIAL)")
 			for _, name in pairs(names) do

--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -1325,12 +1325,12 @@ function R:OnEvent(event, ...)
 			end
 		end
 
-		-- Handle opening Forgotten Chest (Venthyr only chest for Silessa's Battle Harness in Revendreth, Shadowlands)
+		-- Handle opening Forgotten Chest (Shadowlands, Revendreth chest for Stony's Infused Ruby pet and Silessa's Battle Harness mount)
 		if Rarity.isFishing and Rarity.isOpening and Rarity.lastNode and (Rarity.lastNode == L["Forgotten Chest"]) then
-			local names = {"Silessa's Battle Harness"}
+			local names = {"Stony's Infused Ruby", "Silessa's Battle Harness"}
 			Rarity:Debug("Detected Opening on " .. L["Forgotten Chest"] .. " (method = SPECIAL)")
 			for _, name in pairs(names) do
-				local v = self.db.profile.groups.items[name] or self.db.profile.groups.mounts[name]
+				local v = self.db.profile.groups.pets[name] or self.db.profile.groups.mounts[name]
 				if v and type(v) == "table" and v.enabled ~= false then
 					if v.attempts == nil then
 						v.attempts = 1
@@ -1346,23 +1346,6 @@ function R:OnEvent(event, ...)
 		if Rarity.isFishing and Rarity.isOpening and Rarity.lastNode and (Rarity.lastNode == L["Cache of Eyes"]) then
 			local names = {"Luminous Webspinner"}
 			Rarity:Debug("Detected Opening on " .. L["Cache of Eyes"] .. " (method = SPECIAL)")
-			for _, name in pairs(names) do
-				local v = self.db.profile.groups.items[name] or self.db.profile.groups.pets[name]
-				if v and type(v) == "table" and v.enabled ~= false then
-					if v.attempts == nil then
-						v.attempts = 1
-					else
-						v.attempts = v.attempts + 1
-					end
-					self:OutputAttempts(v)
-				end
-			end
-		end
-
-		-- Handle opening Forgotten Chest (Venthyr only chest for Stony's Infused Ruby pet in Revendreth, Shadowlands)
-		if Rarity.isFishing and Rarity.isOpening and Rarity.lastNode and (Rarity.lastNode == L["Forgotten Chest"]) then
-			local names = {"Stony's Infused Ruby"}
-			Rarity:Debug("Detected Opening on " .. L["Forgotten Chest"] .. " (method = SPECIAL)")
 			for _, name in pairs(names) do
 				local v = self.db.profile.groups.items[name] or self.db.profile.groups.pets[name]
 				if v and type(v) == "table" and v.enabled ~= false then

--- a/DB/Nodes.lua
+++ b/DB/Nodes.lua
@@ -242,6 +242,5 @@ R.opennodes = {
 	[L["Secret Treasure"]] = true,
 	[L["Forgotten Chest"]] = true,
 	[L["Cache of Eyes"]] = true,
-	[L["Forgotten Chest"]] = true,
 	[L["Dirty Glinting Object"]] = true
 }

--- a/Locales.lua
+++ b/Locales.lua
@@ -1788,7 +1788,6 @@ L["Forgotten Chest"] = true
 L["Luminous Webspinner"] = true
 L["Cache of Eyes"] = true
 L["Stony's Infused Ruby"] = true
-L["Forgotten Chest"] = true
 L["Smoldering Ember Wyrm"] = true
 L["Bottle of Gloop"] = true
 L["Piccolo of the Flaming Fire"] = true


### PR DESCRIPTION
Fixes the issue reported here: https://www.wowace.com/projects/rarity/issues/469

I also removed some duplicated locales and combined the events for the Forgotten Chest to check for both items at the same time.