### PR TITLE
Add a new setting to hide progress bar sparks

### DIFF
--- a/Core/GUI/AnchoredTrackingBar.lua
+++ b/Core/GUI/AnchoredTrackingBar.lua
@@ -88,10 +88,19 @@ function GUI:UpdateBar()
 		self.barGroup:Lock()
 		self.barGroup:HideAnchor()
 	end
+
+	GUI:UpdateSparks()
 end
 
 function GUI:ToggleProgressBar()
 	Rarity.db.profile.bar.visible = not Rarity.db.profile.bar.visible
 	Rarity.GUI:UpdateBar()
 	Rarity.GUI:UpdateText()
+end
+
+-- NOTE: LibBars doesn't support disabling these properly (remove this later)
+function GUI:UpdateSparks()
+	for index, bar in Rarity.barGroup:IterateBars() do
+		bar.spark:SetShown(Rarity.db.profile.bar.showSpark)
+	end
 end

--- a/Core/GUI/DataBrokerDisplay.lua
+++ b/Core/GUI/DataBrokerDisplay.lua
@@ -191,6 +191,7 @@ function GUI:UpdateText()
 		self.bar:SetIcon(itemTexture or [[Interface\Icons\spell_nature_forceofnature]])
 		self.bar:SetLabel(text)
 		self.bar:SetValue(chance, 100)
+		self.GUI:UpdateSparks() -- NOTE: SetValue always enables sparks (remove once fixed)
 	end
 	if self.hadBarTwo then -- If we've transitioning from 2 bars to 1, hiding/showing the bars collapses them
 		self.barGroup:Hide()
@@ -267,6 +268,7 @@ function GUI:UpdateText()
 			self.bar2:SetIcon(itemTexture or [[Interface\Icons\spell_nature_forceofnature]])
 			self.bar2:SetLabel(text)
 			self.bar2:SetValue(chance, 100)
+			self.GUI:UpdateSparks() -- NOTE: SetValue always enables sparks (remove once fixed)
 		end
 	end
 	self.Profiling:EndTimer("GUI.UpdateText")

--- a/Locales.lua
+++ b/Locales.lua
@@ -2,6 +2,7 @@ local L
 L = LibStub("AceLocale-3.0"):NewLocale("Rarity", "enUS", true)
 
 -- L["AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"] = true
+L["Show Spark"] = true
 L["Xanthous Siphonmite"] = true
 L["Vitriolic Inchshifter"] = true
 L["Veridian Thorntail"] = true

--- a/Modules/Options/Options.lua
+++ b/Modules/Options/Options.lua
@@ -1055,6 +1055,19 @@ function R:PrepareOptions()
 									Rarity.GUI:UpdateText()
 								end,
 							},
+							showSpark = {
+								type = "toggle",
+								order = newOrder(),
+								name = L["Show Spark"],
+								get = function()
+									return self.db.profile.bar.showSpark
+								end,
+								set = function(info, val)
+									self.db.profile.bar.showSpark = val
+									Rarity.GUI:UpdateBar()
+									Rarity.GUI:UpdateText()
+								end,
+							},
 							showText = {
 								type = "toggle",
 								order = newOrder(),

--- a/Options_Defaults.lua
+++ b/Options_Defaults.lua
@@ -125,6 +125,7 @@ function R:PrepareDefaults()
 				rightAligned = false,
 				showIcon = true,
 				showText = true,
+				showSpark = true,
 			},
 			cats = {
 				[CONSTANTS.ITEM_CATEGORIES.CLASSIC] = true,


### PR DESCRIPTION
Because sparks are always shown in the LibBars code, this requires some hacky workarounds.