### PR TITLE
Refactor the processItem GameTooltip hook

### DIFF
--- a/Core/GUI/GameTooltipHooks.lua
+++ b/Core/GUI/GameTooltipHooks.lua
@@ -19,6 +19,7 @@ local tinsert = table.insert
 local CONSTANTS = addonTable.constants
 local colorize = Rarity.Utils.String.Colorize
 local scanTip = Rarity.GUI.scanTip
+local DEBUG_MESSAGE_COLOR = Rarity.Enum.Colors.DebugMessageColor
 --- Constants
 local red = Rarity.Enum.Colors.Red
 local green = Rarity.Enum.Colors.Green
@@ -395,6 +396,12 @@ function Rarity.TooltipProcessItem(tooltip, itemID)
 	end
 
 	Rarity.TooltipAppendLines(tooltip, tooltipLines)
+	if Rarity.db.profile.debugMode then
+		local debugInfo = format("Item ID: %d", itemID)
+		debugInfo = colorize(debugInfo, DEBUG_MESSAGE_COLOR)
+		tooltip:AddLine(" ")
+		tooltip:AddLine(debugInfo)
+	end
 	tooltip:Show()
 
 	return tooltipLines -- Ignored ingame, but useful for debugging/testing

--- a/DB/SharedConstants.lua
+++ b/DB/SharedConstants.lua
@@ -389,6 +389,7 @@ C.Colors = {
 	Gray = { r = 0.5, g = 0.5, b = 0.5 },
 	Black = { r = 0.0, g = 0.0, b = 0.0 },
 	White = { r = 1.0, g = 1.0, b = 1.0 },
+	DebugMessageColor = { r = 0x33 / 255, g = 0xFF / 255, b = 0x85 / 255 },
 }
 
 -- Legacy method of sharing constants (awkward, but better than not sharing them I guess)


### PR DESCRIPTION
Cuts down on repeated and in parts faulty logic that caused items to not always be processed as expected. Specifically, the Headless Horseman container only displayed the first item out of three. Other items are likely to be affected as well:

<img width="252" height="126" alt="image" src="https://github.com/user-attachments/assets/45e6e53c-93f9-4c4f-a699-dea955d141d6" />

The new approach should be flexible enough to also handle unit tooltips later, and hopefully work on Classic/without LibQTip (with minimal changes); it's just a line buffer with a separate render call at the end. I haven't touched those yet, however, so that's mostly a guess. Once the UI boilerplate is isolated it should also be testable offline, which may or may not be worth the effort.

The behavior isn't exactly identical, but I tried to preserve all the user-configurable settings. I'm fairly certain some edge cases will likely cause glitches or missing details, but it should be a lot easier to fix (for me, anyway) and the tooltip isn't a critical feature. 

One of the bigger question marks is how Primal Egg and other containers that reference items outside of Rarity's DB should be handled. For now, the tooltip just displays the item link. Presumably, the code could be simplified if the mounts were added to (or the eggs removed from) the database. There's only a few such items, though, so I didn't want to spend any time on this problem.