### PR TITLE
UI: Show known status and pickpocket requirements in the same line in tooltip

### DIFF
--- a/Core/GUI/GameTooltipHooks.lua
+++ b/Core/GUI/GameTooltipHooks.lua
@@ -125,19 +125,8 @@ local function onTooltipSetUnit(tooltip, data)
 							if v.known or Rarity.db.profile.tooltipAttempts == false then
 								attemptText = ""
 							end
-							GameTooltip:AddLine(
-								colorize(
-									(
-										not rarityAdded
-											and L["Rarity: "] .. (R.db.profile.blankLineAfterRarity and "\n" or "")
-										or ""
-									)
-										.. (itemLink or itemName or v.name)
-										.. attemptText,
-									yellow
-								)
-							)
-							rarityAdded = true
+							local knownText = v.known and (" " .. colorize(L["Already known"], red)) or ""
+							local pickpocketText = ""
 							if v.pickpocket then
 								local class, classFileName = Rarity:GetUnitClass("player")
 								local pickcolor
@@ -146,12 +135,24 @@ local function onTooltipSetUnit(tooltip, data)
 								else
 									pickcolor = red
 								end
-								GameTooltip:AddLine(colorize(L["Requires Pickpocketing"], pickcolor))
+								pickpocketText = " " .. colorize(L["Requires Pickpocketing"], pickcolor)
 							end
-							if v.known then
-								GameTooltip:AddLine(colorize(L["Already known"], red))
-								blankAdded = false
-							end
+							GameTooltip:AddLine(
+								colorize(
+									(
+										not rarityAdded
+											and L["Rarity: "] .. (R.db.profile.blankLineAfterRarity and "\n" or "")
+										or ""
+									)
+										.. (itemLink or itemName or v.name)
+										.. attemptText
+										.. pickpocketText
+										.. knownText,
+									yellow
+								)
+							)
+							rarityAdded = true
+							blankAdded = false
 							GameTooltip:Show()
 						end
 					end
@@ -337,6 +338,7 @@ local function onTooltipSetUnit(tooltip, data)
 										if vv.known or Rarity.db.profile.tooltipAttempts == false then
 											attemptText = ""
 										end
+										local knownText = vv.known and (" " .. colorize(L["Already known"], red)) or ""
 										GameTooltip:AddLine(
 											colorize(
 												(
@@ -345,15 +347,14 @@ local function onTooltipSetUnit(tooltip, data)
 													or ""
 												)
 													.. (itemLink or itemName or vv.name)
-													.. attemptText,
+													.. attemptText
+													.. knownText,
 												yellow
 											)
 										)
 										rarityAdded = true
-										if vv.known then
-											GameTooltip:AddLine(colorize(L["Already known"], red))
-											blankAdded = false
-										end
+										blankAdded = false
+
 										GameTooltip:Show()
 									end
 								end


### PR DESCRIPTION
Before:
<img width="596" height="1972" alt="image" src="https://github.com/user-attachments/assets/4e99d0a0-989a-4a15-b523-456dff4e9ae1" />

After:
<img width="596" height="1684" alt="image" src="https://github.com/user-attachments/assets/540c07bb-a7a8-45f2-8a4f-275397b9eea0" />
