### PR TITLE
Disable the WowAce localization check in forked repositories

### DIFF
--- a/.github/workflows/check-wowace-locales.yml
+++ b/.github/workflows/check-wowace-locales.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   toc:
     name: Check localization phrases
+    if: github.event.pull_request.head.repo.fork == false
     runs-on: macos-latest
 
     steps:


### PR DESCRIPTION
Forks don't have access to the secrets required to use the CF API token, so this workflow always fails.

They don't need to run the check anyway, since it mainly serves as a reminder to not leave localization  in an outdated state for extensive periods of time. A better solution would be to handle the localization entirely without requiring the use of WowAce's REST API, but that's not how things are right now. (Note: All WIP branches by contributors will have to be rebased)