### PR TITLE
Update the changelog for r751-release

### DIFF
--- a/CHANGES.MD
+++ b/CHANGES.MD
@@ -1,8 +1,7 @@
-**r750:**
+**r751:**
 
 Additions:
->  Added tracking for The Headless Horseman's Ghoulish Charger
-<br> Added tracking for Love Witch's Sweeper
+> Added tracking for Black Whirlwind (toy)
 
 Contributors (in alphabetical order):
 > Ellezanor

--- a/Changes.lua
+++ b/Changes.lua
@@ -1,4 +1,10 @@
 local changes = {
+	["r751"] = {
+		additions = {
+			"Added tracking for Black Whirlwind (toy)",
+		},
+		contributors = { "Ellezanor" },
+	},
 	["r750"] = {
 		additions = {
 			" Added tracking for The Headless Horseman's Ghoulish Charger",


### PR DESCRIPTION
Mostly behind-the-scenes stuff here, but it's been ages since a proper release was published. As a result, several people have been reporting the TOC version mismatch "error" (WOW client complains and disables the addon). Plus, if there's any problems with the synchronous DB loading approach I'd rather fix that ASAP and not when the pre-patch hits.