### PR TITLE
Add a workaround for outdated LE_EXPANSION_* values on Classic

### DIFF
--- a/DB/Mounts/Midnight.lua
+++ b/DB/Mounts/Midnight.lua
@@ -2,7 +2,7 @@ local addonName, addonTable = ...
 local L = LibStub("AceLocale-3.0"):GetLocale("Rarity")
 local CONSTANTS = addonTable.constants
 
-if LE_EXPANSION_LEVEL_CURRENT < LE_EXPANSION_MIDNIGHT then
+if not LE_EXPANSION_MIDNIGHT or LE_EXPANSION_LEVEL_CURRENT < LE_EXPANSION_MIDNIGHT then
 	return {}
 end
 

--- a/DB/Pets/Midnight.lua
+++ b/DB/Pets/Midnight.lua
@@ -3,7 +3,7 @@ local addonName, addonTable = ...
 local L = LibStub("AceLocale-3.0"):GetLocale("Rarity")
 local CONSTANTS = addonTable.constants
 
-if LE_EXPANSION_LEVEL_CURRENT < LE_EXPANSION_MIDNIGHT then
+if not LE_EXPANSION_MIDNIGHT or LE_EXPANSION_LEVEL_CURRENT < LE_EXPANSION_MIDNIGHT then
 	return {}
 end
 

--- a/DB/Toys/Midnight.lua
+++ b/DB/Toys/Midnight.lua
@@ -3,7 +3,7 @@ local addonName, addonTable = ...
 local L = LibStub("AceLocale-3.0"):GetLocale("Rarity")
 local CONSTANTS = addonTable.constants
 
-if LE_EXPANSION_LEVEL_CURRENT < LE_EXPANSION_MIDNIGHT then
+if not LE_EXPANSION_MIDNIGHT or LE_EXPANSION_LEVEL_CURRENT < LE_EXPANSION_MIDNIGHT then
 	return {}
 end
 


### PR DESCRIPTION
It seems that the technology to automatically synchronize enum values hasn't yet arrived at Blizzard HQ.