### PR TITLE
On combat fix

### DIFF
--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -83,7 +83,7 @@ function EventHandlers:Register()
 	self:RegisterEvent("ISLAND_COMPLETED", "OnIslandCompleted")
 	self:RegisterEvent("UNIT_SPELLCAST_SUCCEEDED", "OnSpellcastSucceeded")
 	self:RegisterEvent("QUEST_TURNED_IN", "OnQuestTurnedIn")
-	
+
 	if LE_EXPANSION_LEVEL_CURRENT >= LE_EXPANSION_MISTS_OF_PANDARIA then
 		self:RegisterEvent("SHOW_LOOT_TOAST", "OnShowLootToast")
 	end
@@ -96,8 +96,6 @@ function EventHandlers:Register()
 
 	self:RegisterEvent("PLAYER_INTERACTION_MANAGER_FRAME_SHOW", "OnPlayerInteractionFrameShow")
 	self:RegisterEvent("PLAYER_INTERACTION_MANAGER_FRAME_HIDE", "OnPlayerInteractionFrameHide")
-	
-	--]]
 end
 
 -- TODO: Move elsewhere/refactor


### PR DESCRIPTION
`PARTY_KILL` fires on any kill (even solo), which means we don't have to check for `UNIT_DIED` anymore. `PARTY_KILL` dos not fire on random people outside of the group killing things, so no need to check for `COMBATLOG_OBJECT_AFFILIATION_MINE|PARTY|RAID` anymore. 

Event passes the target GUID, so I just passed it to `GetNPCIDFromGUID()` and the rest of the functionality stays unchanged