### PR TITLE
Add a workaround for outdated LE_EXPANSION_* values on Classic

### DIFF
--- a/Modules/Options/Options.lua
+++ b/Modules/Options/Options.lua
@@ -959,7 +959,8 @@ function R:PrepareOptions()
 									Rarity.GUI:UpdateText()
 								end,
 								hidden = function()
-									return LE_EXPANSION_LEVEL_CURRENT < LE_EXPANSION_MIDNIGHT
+									return not LE_EXPANSION_MIDNIGHT
+										or (LE_EXPANSION_LEVEL_CURRENT < LE_EXPANSION_MIDNIGHT)
 								end,
 							},
 						}, -- args


### PR DESCRIPTION
Missed that one when adding the same check to the DB files in f644e3e894bd6f4b19007658fdf091d194cc90db.

It causes a Lua error when attempting to open the Options UI on Classic (Era).