### PR TITLE
Display map names below zone IDs in the Options UI

### DIFF
--- a/Core/Interoperability/Blizzard/MapInfo.lua
+++ b/Core/Interoperability/Blizzard/MapInfo.lua
@@ -11,4 +11,24 @@ function MapInfo.GetMapNameByID(uiMapID)
 	return UiMapDetails and UiMapDetails.name
 end
 
+local L = LibStub("AceLocale-3.0"):GetLocale("Rarity")
+function MapInfo.GetLocalizedMapNamesForItem(item)
+	local zones = item.zones or {}
+	local mapNames = {}
+
+	for index, zoneID in ipairs(zones) do
+		local mapID = tonumber(zoneID)
+		if not mapID then -- Zone or subzone name (not an actual ID)
+			table.insert(mapNames, zoneID)
+		else
+			local mapName = MapInfo.GetMapNameByID(mapID) or L["Unknown"]
+			local prefix = mapName
+			local suffix = format(" (%s)", zoneID)
+			table.insert(mapNames, prefix .. suffix)
+		end
+	end
+
+	return mapNames
+end
+
 Rarity.MapInfo = MapInfo

--- a/Modules/Options/Options.lua
+++ b/Modules/Options/Options.lua
@@ -2292,6 +2292,23 @@ function R:CreateGroup(options, group, isUser)
 					end,
 					disabled = not isUser,
 				},
+				zoneNamesLocalized = {
+					type = "input",
+					width = "double",
+					disabled = true,
+					order = newOrder(),
+					name = "",
+					get = function()
+						return colorize(table.concat(Rarity.MapInfo.GetLocalizedMapNamesForItem(item), ", "), green)
+					end,
+					hidden = function()
+						if item.method == ZONE or item.method == FISHING then
+							return false
+						else
+							return true
+						end
+					end,
+				},
 				items = {
 					type = "input",
 					order = newOrder(),


### PR DESCRIPTION
Not what I'd consider great UX, but it should still make it easier to see when the IDs are wrong or missing (e.g., for custom items or on Classic Era). People have frequently been confused after they entered the wrong ID from wowhead, so this might help.

Unfortunately, I couldn't figure out a better way to do this with AceConfig and I don't want to spend too much time on it either.

---

Valid IDs:

<img width="466" height="139" alt="image" src="https://github.com/user-attachments/assets/3860e16c-c25c-4e59-aa65-e875175f0ad5" />

Invalid IDs:

<img width="476" height="143" alt="image" src="https://github.com/user-attachments/assets/2666ec50-0105-4cd1-9899-2be053c39436" />

Subzone names:

<img width="501" height="140" alt="image" src="https://github.com/user-attachments/assets/39ac9962-7526-4962-8388-6430b3386a7e" />
