### PR TITLE
Disable processing of secret unit identities

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -49,6 +49,9 @@ globals = {
 	"Rarity",
 	"RarityDB",
 
+	-- Builtins (Blizzard extensions)
+	"issecretvalue",
+
 	-- Shared constants (Blizzard interface)
 	"UIERRORS_HOLD_TIME",
 	"SHOW_COMBAT_TEXT",

--- a/Core/Detection.lua
+++ b/Core/Detection.lua
@@ -16,8 +16,6 @@ local GetLFGRandomDungeonInfo = GetLFGRandomDungeonInfo
 local GetLFGDungeonInfo = GetLFGDungeonInfo
 local GetLFGDungeonRewards = GetLFGDungeonRewards
 local GetStatistic = GetStatistic
-local UnitName = UnitName
-local UnitGUID = UnitGUID
 local InCombatLockdown = InCombatLockdown
 local GetAchievementNumCriteria = GetAchievementNumCriteria
 
@@ -157,8 +155,8 @@ function R:BuildStatistics(reason)
 		if not Rarity.db.profile.accountWideStatistics then
 			Rarity.db.profile.accountWideStatistics = {}
 		end
-		local charName = UnitName("player")
-		local charGuid = UnitGUID("player")
+		local charName = Rarity:GetUnitName("player")
+		local charGuid = Rarity:GetUnitGUID("player")
 		if charName and charGuid then
 			if not Rarity.db.profile.accountWideStatistics[charGuid] then
 				Rarity.db.profile.accountWideStatistics[charGuid] = {}

--- a/Core/GUI/GameTooltipHooks.lua
+++ b/Core/GUI/GameTooltipHooks.lua
@@ -46,13 +46,20 @@ local function onTooltipSetUnit(tooltip, data)
 
 	-- If debug mode is on, find NPCID from mouseover target and append it to the tooltip
 	if R.db.profile.debugMode then
-		GameTooltip:AddLine("NPCID: " .. R:GetNPCIDFromGUID(UnitGUID("mouseover")), 255, 255, 255)
+		local npcID = R:GetNPCIDFromGUID(Rarity:GetUnitGUID("mouseover"))
+		local text = npcID or "<secret>"
+		GameTooltip:AddLine("NPC ID: " .. text, 255, 255, 255)
 	end
 
 	local name, unit = self:GetUnit()
 	if not unit then
 		return
 	end
+
+	if issecretvalue and issecretvalue(unit) then
+		return
+	end
+
 	local creatureType = UnitCreatureType(unit)
 	-- Rarity:Debug("Creature type: "..(creatureType or "nil").." (translation: "..(lbct[creatureType] or "nil")..")")
 	if
@@ -66,11 +73,14 @@ local function onTooltipSetUnit(tooltip, data)
 		return
 	end
 
-	local guid = UnitGUID(unit)
+	local guid = Rarity:GetUnitGUID(unit)
 	if not unit or not guid then
 		return
 	end
 	local npcid = R:GetNPCIDFromGUID(guid)
+	if not npcid then
+		return
+	end
 	if not UnitCanAttack("player", unit) and not Rarity.db.profile.oneTimeItems[npcid] then
 		return
 	end -- Something you can't attack (but allow this for one-time items)
@@ -129,7 +139,7 @@ local function onTooltipSetUnit(tooltip, data)
 							)
 							rarityAdded = true
 							if v.pickpocket then
-								local class, classFileName = UnitClass("player")
+								local class, classFileName = Rarity:GetUnitClass("player")
 								local pickcolor
 								if classFileName == "ROGUE" then
 									pickcolor = green

--- a/Core/GUI/MainWindow.lua
+++ b/Core/GUI/MainWindow.lua
@@ -331,7 +331,7 @@ local function showSubTooltip(cell, item)
 		tooltip2AddLine(colorize(R.string_methods[actualMethod], blue))
 	end
 	if item.pickpocket then
-		local class, classFileName = UnitClass("player")
+		local class, classFileName = Rarity:GetUnitClass("player")
 		local pickcolor
 		if classFileName == "ROGUE" then
 			pickcolor = green
@@ -853,8 +853,8 @@ local function addGroup(group, requiresGroup)
 			)
 		then
 			local classGood = true
-			local playerClass = select(2, UnitClass("player"))
-			if v.disableForClass and v.disableForClass[playerClass] then
+			local playerClass = select(2, Rarity:GetUnitClass("player"))
+			if playerClass and v.disableForClass and v.disableForClass[playerClass] then
 				classGood = false
 			end
 
@@ -1088,7 +1088,7 @@ local function addGroup(group, requiresGroup)
 							status = colorize(L["Unavailable"], gray)
 						end
 						if v.pickpocket then
-							local class, classFileName = UnitClass("player")
+							local class, classFileName = Rarity:GetUnitClass("player")
 							if classFileName ~= "ROGUE" then
 								status = colorize(L["Unavailable"], gray)
 							end


### PR DESCRIPTION
As of 12.0, none of the information related to NPCs is available to addons - at least for instanced content. This means that a large number of items previously supported by Rarity can no longer be tracked. I've been working on support for encounter IDs, which may cover many of the items that players would be interested in from instanced content. This change, however, only adds guards for the secret values and removes the Lua errors that were popping up constantly.

I don't think it will be possible to track regular NPCs, but I'm not removing them from the database since it should still work on Classic. Unfortunately, I'm unable to test on Classic Era/MOP/Anniversary. For what it's worth, most of the items in the DB seem to be using kill statistics or are named encounters.