### PR TITLE
Fix secret value crash in ScanCalendar (WoW 12.0.0+)

### DIFF
--- a/Core/Detection.lua
+++ b/Core/Detection.lua
@@ -68,10 +68,19 @@ function R:ScanCalendar(reason)
 
 	for i = 1, numEvents, 1 do
 		local calendarEvent = C_Calendar.GetDayEvent(monthOffset, day, i)
-		assert(calendarEvent.eventID, "Calendar event IDs should now be available in all WOW product lines")
 
-		if calendarEvent.calendarType == "HOLIDAY" then
-			Rarity.activeHolidayEvents[calendarEvent.eventID] = calendarEvent
+		-- In WoW 12.0.0+, calendar fields may be secret values that cannot be compared or used as table keys.
+		-- Skip entries with secret fields rather than erroring out.
+		local eventID = calendarEvent.eventID
+		local calendarType = calendarEvent.calendarType
+		if issecretvalue and (issecretvalue(eventID) or issecretvalue(calendarType)) then
+			-- Secret values cannot be compared or used as table keys; skip this entry
+		else
+			assert(eventID, "Calendar event IDs should now be available in all WOW product lines")
+
+			if calendarType == "HOLIDAY" then
+				Rarity.activeHolidayEvents[eventID] = calendarEvent
+			end
 		end
 	end
 end


### PR DESCRIPTION
### Problem

In WoW 12.0.0 (Midnight), `C_Calendar.GetDayEvent()` can return fields as **secret values** that cannot be compared or used as table keys by addon code. This causes a crash at `Detection.lua:73`:
```
attempt to compare field 'calendarType' (a secret string value tainted by 'Rarity')
```
### Fix
Added `issecretvalue()` guards on `calendarType` and `eventID` before they are used in comparisons or as table keys. Calendar entries with secret fields are silently skipped.

The `issecretvalue and ...` pattern ensures backward compatibility with pre-12.0.0 clients.

### Impact
Minimal. In the unlikely case calendar data is secret at scan time, a holiday event may not be detected until the next scan. This is preferable to a hard error that breaks detection entirely.
