### PR TITLE
Fix LOOT_READY handling for world objects

### DIFF
--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -1244,10 +1244,7 @@ end
 -------------------------------------------------------------------------------------
 function R:OnLootReady(event, ...)
 	do
-		local targetGUID = Rarity:GetUnitGUID("target")
-		if not targetGUID then
-			return
-		end
+		local targetGUID = Rarity:GetUnitGUID("target") or "N/A"
 		self:Debug("LOOT_READY with target: " .. targetGUID)
 
 		-- Two LOOT_READY events may trigger when the loot window opens, in which case this prevents double counting


### PR DESCRIPTION
Regression introduced by adding the secret guard. I forgot that the world object handling is still in here. There's another guard further down, so that world objects should be processed first (untested).

Reported by clamguy on Discord.

---

Tagged as `r752-alpha-7`, but not going to merge this yet. Needs testing/review (there may be a better way).