### PR TITLE
Guard against secret values in ScanCalendar on WoW 12.0.0+

### DIFF
--- a/Core/Detection.lua
+++ b/Core/Detection.lua
@@ -66,9 +66,13 @@ function R:ScanCalendar(reason)
 
 	for i = 1, numEvents, 1 do
 		local calendarEvent = C_Calendar.GetDayEvent(monthOffset, day, i)
-		assert(calendarEvent.eventID, "Calendar event IDs should now be available in all WOW product lines")
+		if not calendarEvent or not calendarEvent.eventID then
+			break
+		end
 
-		if calendarEvent.calendarType == "HOLIDAY" then
+		-- Guard against secret values in calendar fields (WoW 12.0.0+)
+		local calType = calendarEvent.calendarType
+		if not (issecretvalue and issecretvalue(calType)) and calType == "HOLIDAY" then
 			Rarity.activeHolidayEvents[calendarEvent.eventID] = calendarEvent
 		end
 	end


### PR DESCRIPTION
## Summary

Fix Lua error in `ScanCalendar()` on WoW 12.0.0+ (Midnight) caused by secret string values in calendar event fields.

## Problem

`C_Calendar.GetDayEvent()` can return secret string values for fields like `calendarType` on WoW 12.0.0+. Comparing these with `==` causes:

```
attempt to compare field 'calendarType' (a secret string value tainted by 'Rarity')
```

## Solution

- Add `issecretvalue()` guard before comparing `calendarEvent.calendarType`
- Replace the `assert(calendarEvent.eventID)` with a nil check to handle missing calendar data gracefully instead of crashing

## Test plan

- [ ] No calendar-related Lua errors on WoW 12.0.0+
- [ ] Holiday events still detected correctly (Rarity shows holiday item reminders)