### PR TITLE
Remove Mysterious Skyshards from the database

### DIFF
--- a/DB/Toys/Midnight.lua
+++ b/DB/Toys/Midnight.lua
@@ -8,18 +8,6 @@ if not LE_EXPANSION_MIDNIGHT or LE_EXPANSION_LEVEL_CURRENT < LE_EXPANSION_MIDNIG
 end
 
 local midnightToys = {
-	["Mysterious Skyshards"] = {
-		cat = CONSTANTS.ITEM_CATEGORIES.MIDNIGHT,
-		type = CONSTANTS.ITEM_TYPES.ITEM,
-		method = CONSTANTS.DETECTION_METHODS.ZONE,
-		name = L["Mysterious Skyshards"],
-		itemId = 255826,
-		zones = { tostring(CONSTANTS.UIMAPIDS.HARANDAR) },
-		chance = 1000,
-		coords = { { m = CONSTANTS.UIMAPIDS.HARANDAR } },
-		repeatable = true,
-		requiresCompletedQuestId = { 90474 }, -- The Legend of Aln'sharan
-	},
 	["Nether-Warped Egg"] = {
 		cat = CONSTANTS.ITEM_CATEGORIES.MIDNIGHT,
 		type = CONSTANTS.ITEM_TYPES.ITEM,

--- a/Locales.lua
+++ b/Locales.lua
@@ -8,7 +8,6 @@ L["Keys to the Big G"] = true
 L["Reins of the Ascendant Skyrazor"] = true
 L["Black Whirlwind"] = true
 L["Spring Butterfly"] = true
-L["Mysterious Skyshards"] = true
 L["Nether-Warped Egg"] = true
 L["Lucent Hawkstrider"] = true
 L["Bubbly Snapling"] = true


### PR DESCRIPTION
They don't appear to be sufficiently rare to warrant the inclusion. Also, several people have asked for screenshots to be disabled for them. Goodbye, for now.