### PR TITLE
Fix for secret value in GetUnit of 12.0.5 GameTooltip

### DIFF
--- a/Core/GUI/GameTooltipHooks.lua
+++ b/Core/GUI/GameTooltipHooks.lua
@@ -51,8 +51,8 @@ local function onTooltipSetUnit(tooltip, data)
 		GameTooltip:AddLine("NPC ID: " .. text, 255, 255, 255)
 	end
 
-	local name, unit = self:GetUnit()
-	if not unit then
+	local name, unit, secret = Rarity.GetUnitFromTooltip(self)
+	if secret or not unit then
 		return
 	end
 
@@ -520,4 +520,23 @@ function Rarity.TooltipProcessItemInfo(tooltip, item)
 	end
 
 	return itemText .. attemptText
+end
+
+function Rarity.GetUnitFromTooltip(tooltip)
+	local unit, name
+
+	if tooltip:IsTooltipType(Enum.TooltipDataType.Unit) then
+		local tooltipData = tooltip:GetPrimaryTooltipData();
+		local guid = tooltipData.guid;
+		unit = guid and UnitTokenFromGUID(guid);
+
+		if issecretvalue and issecretvalue(unit) then
+			-- Run away!
+			return nil, nil, true
+		end
+
+		name = unit and UnitName(unit);
+
+		return name, unit, false
+	end
 end


### PR DESCRIPTION
It appears that the call to `GetUnit` on 54 of `GameTooltipHooks` hits `GetDisplayedUnit` in `Blizzard_SharedXMLGame/Tooltip/TooltipUtil` which isn't secret value safe, and, when you're in an instance, the value is now secret.

I've made a copy of `GetDisplayedUnit` in `GetTooltipHooks` which is more secret safe and it seems to be stable. Tried it in a delve and it held up at least.