### PR TITLE
Add searchbars in mounts, pets and toys/items options tabs

### DIFF
--- a/Locales.lua
+++ b/Locales.lua
@@ -1025,6 +1025,13 @@ L["When on, Rarity will generate an achievement alert pop-up indicating that you
 L["Show achievement"] = true
 L["Primary tooltip show delay"] = true
 L["When you move your mouse over the Rarity minimap icon, it will take this long before the GUI opens."] = true
+L["Search"] = true
+L["Search mounts"] = true
+L["Search battle pets"] = true
+L["Search toys & items"] = true
+L["Clear"] = true
+L["Clear the search filter."] = true
+L["Filter the list by name or item ID."] = true
 
 -- Sources
 -- L[""] = true -> This seems pointless and breaks the import feature on WowAce, therefore I disabled it. I left it here because I really don't understand why it has been added and kept around for almost 4 years, so...eh ¯\_(ツ)_/¯

--- a/Modules/Options/Options.lua
+++ b/Modules/Options/Options.lua
@@ -182,6 +182,27 @@ local function sort(t)
 	return nt
 end
 
+local SEARCH_FILTER_CONFIG = {
+	mounts = { label = L["Search mounts"] },
+	pets = { label = L["Search battle pets"] },
+	items = { label = L["Search toys & items"] },
+}
+
+local function itemMatchesSearch(item, searchText)
+	local search = strlower(strtrim(searchText or ""))
+	if search == "" then
+		return true
+	end
+	local itemName = select(2, GetItemInfo(item.itemId or 0)) or item.name or ""
+	if strfind(strlower(itemName), search, 1, true) then
+		return true
+	end
+	if item.itemId and tostring(item.itemId):find(search, 1, true) then
+		return true
+	end
+	return false
+end
+
 local function alert(msg)
 	StaticPopupDialogs["RARITY_OPTIONS_ALERT"] = {
 		text = msg,
@@ -1589,9 +1610,9 @@ function R:PrepareOptions()
 	} -- self.options
 
 	-- Create the options for each group of items
-	self:CreateGroup(self.options.args.mounts, self.db.profile.groups.mounts, false)
-	self:CreateGroup(self.options.args.companions, self.db.profile.groups.pets, false)
-	self:CreateGroup(self.options.args.items, self.db.profile.groups.items, false)
+	self:CreateGroup(self.options.args.mounts, self.db.profile.groups.mounts, false, "mounts")
+	self:CreateGroup(self.options.args.companions, self.db.profile.groups.pets, false, "pets")
+	self:CreateGroup(self.options.args.items, self.db.profile.groups.items, false, "items")
 	self:CreateGroup(self.options.args.custom, self.db.profile.groups.user, true)
 
 	self.advancedSettings = {
@@ -1786,7 +1807,7 @@ end -- function R:PrepareOptions()
 -- ITEM GROUPS
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-function R:CreateGroup(options, group, isUser)
+function R:CreateGroup(options, group, isUser, searchFilterKey)
 	options.args = {
 		name = {
 			-- type = "execute", -- Why?
@@ -1823,6 +1844,39 @@ function R:CreateGroup(options, group, isUser)
 		},
 	}
 
+	if searchFilterKey then
+		self.optionsSearchFilters = self.optionsSearchFilters or {}
+		local searchConfig = SEARCH_FILTER_CONFIG[searchFilterKey]
+		options.args.searchFilter = {
+			type = "input",
+			order = 0,
+			width = "double",
+			name = searchConfig and searchConfig.label or L["Search"],
+			desc = L["Filter the list by name or item ID."],
+			get = function()
+				return self.optionsSearchFilters[searchFilterKey] or ""
+			end,
+			set = function(info, val)
+				self.optionsSearchFilters[searchFilterKey] = strtrim(val or "")
+				LibStub("AceConfigRegistry-3.0"):NotifyChange("Rarity")
+			end,
+		}
+		options.args.searchClear = {
+			type = "execute",
+			order = 1,
+			width = "half",
+			name = L["Clear"],
+			desc = L["Clear the search filter."],
+			func = function()
+				self.optionsSearchFilters[searchFilterKey] = ""
+				LibStub("AceConfigRegistry-3.0"):NotifyChange("Rarity")
+			end,
+			disabled = function()
+				return strtrim(self.optionsSearchFilters[searchFilterKey] or "") == ""
+			end,
+		}
+	end
+
 	local g = sort(group)
 	for itemkey, item in pairs(g) do
 		local optionkey = tostring(newOrder())
@@ -1832,6 +1886,14 @@ function R:CreateGroup(options, group, isUser)
 			name = function()
 				return select(2, GetItemInfo(item.itemId or 0)) or item.name
 			end,
+			hidden = searchFilterKey
+				and function()
+					return not itemMatchesSearch(
+						item,
+						(self.optionsSearchFilters or {})[searchFilterKey]
+					)
+				end
+				or nil,
 			args = {
 				--  head = { -- Why?
 				-- 	 type = "description",


### PR DESCRIPTION
With each new expansion release, the lists of items in the options tabs keep getting longer, and it takes quite a while to scroll down to what you're looking for.
This PR adds independent search bars for each tab that can be cleared. You can search by the object's name or by its ID.