### PR TITLE
Core: Use C_AddOns.LoadAddOn instead of the removed UIParentLoadAddOn (12.1)

### DIFF
--- a/Core/Collections.lua
+++ b/Core/Collections.lua
@@ -18,6 +18,7 @@ local tonumber = tonumber
 -- WOW APIs
 local PlayerHasToy = PlayerHasToy
 local InCombatLockdown = InCombatLockdown
+local LoadAddOn = _G.C_AddOns.LoadAddOn
 local C_TransmogCollection = C_TransmogCollection
 local C_MountJournal = C_MountJournal
 local C_PetJournal = C_PetJournal
@@ -68,7 +69,7 @@ function Collections:ScanToys(reason)
 	if not Rarity.toysScanned then
 		if not ToyBox_OnLoad then
 			self:Debug("Loading Blizzard_Collections addon so the ToyBox can be scanned")
-			UIParentLoadAddOn("Blizzard_Collections")
+			LoadAddOn("Blizzard_Collections")
 		end
 	end
 

--- a/Core/GUI/MainWindow.lua
+++ b/Core/GUI/MainWindow.lua
@@ -10,6 +10,7 @@ local GetItemInfo = _G.C_Item.GetItemInfo
 local GetBestMapForUnit = C_Map.GetBestMapForUnit
 local IsWorldQuestActive = C_TaskQuest.IsActive
 local IsQuestFlaggedCompleted = _G.C_QuestLog.IsQuestFlaggedCompleted
+local LoadAddOn = _G.C_AddOns.LoadAddOn
 local C_Covenants = _G.C_Covenants
 
 local FormatTime = Rarity.Utils.PrettyPrint.FormatTime
@@ -1155,7 +1156,7 @@ local function addGroup(group, requiresGroup)
 										Rarity:Print(text)
 										if CVarCallbackRegistry:GetCVarValueBool("enableFloatingCombatText") then
 											if type(CombatText_AddMessage) == "nil" then
-												UIParentLoadAddOn("Blizzard_CombatText")
+												LoadAddOn("Blizzard_CombatText")
 											end
 											CombatText_AddMessage(text, CombatText_StandardScroll, 1, 1, 1, true, false)
 										else


### PR DESCRIPTION
Patch 12.1.0 [renamed the global `UIParentLoadAddOn` to `LoadAddOnWithErrorHandling`](https://warcraft.wiki.gg/wiki/Patch_12.1.0/API_changes), so the old name is now `nil` on Retail. Rarity calls it in two places.

### The login-path one breaks the addon

`Collections:ScanToys` runs during enable, so the `nil` call throws and aborts the rest of `DoEnable`:

```
1x Rarity/Core/Collections.lua:71: attempt to call a nil value
[Rarity/Core/Collections.lua]:71: in function 'ScanToys'
[Rarity/Core/Collections.lua]:299: in function 'ScanExistingItems'
[Rarity/Core.lua]:196: in function 'DoEnable'
[Rarity/Core.lua]:149: in function <Rarity/Core.lua:148>
```

Because it throws *inside* `DoEnable`, everything after `Core.lua:196` is skipped on every login — `ScanBags`, `OnBagUpdate`, `OnCurrencyUpdate`, `UpdateInterestingThings`, `Tracking:FindTrackedItem` and `GUI:UpdateText`. The user-visible symptom is "Rarity doesn't load", not just one error.

The second call site (`Core/GUI/MainWindow.lua`, holiday reminder) is latent — it needs `enableFloatingCombatText` on plus a holiday item due — so it's in a separate commit.

### Why `C_AddOns.LoadAddOn` and not the new global name

The rename is **Mainline-only**, so a direct swap to `LoadAddOnWithErrorHandling` would trade a Retail break for a Classic one. Checked against Blizzard's source:

| | `UIParentLoadAddOn` | `LoadAddOnWithErrorHandling` | `C_AddOns.LoadAddOn` |
|---|---|---|---|
| Retail 12.1 | gone — and [`Deprecated_12_1_0.lua`](https://github.com/Gethe/wow-ui-source/blob/live/Interface/AddOns/Blizzard_Deprecated/Mainline/Deprecated_12_1_0.lua) has no compat alias, so it is genuinely `nil` | yes | yes (12.1.0) |
| Classic Era / MoP Classic | still defined, [`Blizzard_UIParent/Shared/UIParent.lua:250`](https://github.com/Gethe/wow-ui-source/blob/classic_era/Interface/AddOns/Blizzard_UIParent/Shared/UIParent.lua#L250) | **no** | yes (1.15.9 / 5.5.4) |

`C_AddOns.LoadAddOn` is the only single call that works on all three flavors in `## Interface: 120007, 50503, 11508`, so no name-fallback chain is needed.

It's also already how this addon loads on-demand addons — `Core.lua:113`, `Core/GUI.lua:34`, `Core/Profiling.lua:6`, `Core/GUI/DataBrokerDisplay.lua:15`, `Core/EventHandlers.lua:26` all upvalue it unconditionally at file scope under this same multi-flavor TOC (and `Core/Profiling.lua:43` loads `Blizzard_DebugTools` this exact way), which is in-repo proof that `C_AddOns` is present on the Classic flavors too. The behavioral difference is that it returns `loaded, reason` instead of popping an error dialog; neither call site inspects the result.

**Classic impact specifically:** neither changed line is a behavior change there.
- `Collections.lua` — the line is unreachable on Classic Era anyway: `ScanToys` returns at the `C_ToyBox.GetNumToys() == 0` guard, per its own comment ("Can't load Blizzard_Collections since it's broken in Classic Era").
- `MainWindow.lua` — `Libs/LibSink-2.0/LibSink-2.0.lua:33-40` already loads `Blizzard_CombatText` via `C_AddOns.LoadAddOn` (with a legacy fallback) on every flavor this addon ships to.

### Deliberately out of scope

- **No TOC bump.** #978 covers interface versions, and `check-toc-version` is a separate concern — kept out so this stays a 4-line review.
- **The unconditional `CombatText_AddMessage` at `MainWindow.lua:1160`** is a pre-existing latent `nil` call if `Blizzard_CombatText` fails to load. Left alone.
- **The now-unused `UIParentLoadAddOn` entry in `.luacheckrc`** — harmless (unused whitelist entries don't warn), and not worth a third file in the diff.
- I also swept the rest of `Core.lua`/`Core/`/`Utils/` against the full 12.1 change list — every API identifier, all 32 registered event strings, and every CVar read. This is the only breakage. `getglobal`/`setglobal` (deprecated in 12.1) aren't used, and the `UnitClass`/`UnitIsPVP` secret-value changes are already covered: `UnitClass` only ever runs via `Rarity:GetUnitClass("player")`, and the one `UnitIsPVP` call is behind the `Rarity:GetUnitGUID` secret guard from #973.

### Testing

Verified on 12.1.0 (`120100`) live: `/reload` no longer throws and the addon initializes. The post-`DoEnable` steps this unblocks (bag/currency scan, tracking, GUI text) have not been individually exercised yet. Not tested on Classic — see the Classic-impact note above for why both lines should be inert there.

CI gates I could reproduce locally, both green:
- **Autoformat** — `stylua --check` with the exact CI version (v0.17.1) on both files, plus `./autoformat.sh` followed by `git diff --exit-code -b .`: no drift.
- **Automated Testing** — unaffected: `Tests/RarityCoreSetup.lua` only `dofile`s `Libs/*`, `Locales.lua` and `Utils/PrettyPrint.lua`, so neither changed file is loaded by the harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
