### PR TITLE
Fix/wow 12 1 0 compatibility

### DIFF
--- a/CHANGES.MD
+++ b/CHANGES.MD
@@ -1,3 +1,19 @@
+**r752:**
+
+Fixes:
+> Updated TOC interface version to support WoW 12.0.5
+> Fixed event handlers broken by WoW 12.0.5 API changes
+> Added missing constants to SharedConstants for 12.0.5 compatibility
+> Fixed minor Core.lua adjustments for the new client version
+
+Improvements:
+> Improved DataBroker tracking bar layout: item name is now shown on the left label and attempt/chance stats on the right via SetTimerLabel, making the display cleaner
+
+Contributors (in alphabetical order):
+> romeuwb
+
+---
+
 **r751:**
 
 Additions:

--- a/CHANGES.MD
+++ b/CHANGES.MD
@@ -1,3 +1,14 @@
+**r753:**
+
+Fixes:
+> Updated TOC interface version to support WoW 12.1.0 (120100)
+> Replaced deprecated UIParentLoadAddOn with LoadAddOnWithErrorHandling in Collections.lua and MainWindow.lua (API renamed in 12.1.0)
+
+Contributors (in alphabetical order):
+> romeuwb
+
+---
+
 **r752:**
 
 Fixes:

--- a/Core.lua
+++ b/Core.lua
@@ -103,7 +103,8 @@ local GetLootSourceInfo = _G.GetLootSourceInfo
 local GetBestMapForUnit = _G.C_Map.GetBestMapForUnit
 local GetMapInfo = _G.C_Map.GetMapInfo
 local C_Timer = _G.C_Timer
-local IsSpellKnown = _G.IsSpellKnown
+-- IsSpellKnown was moved to C_Spell.IsSpellKnown in WoW 12.0.0 (Midnight); use with fallback for compatibility
+local IsSpellKnown = (_G.C_Spell and _G.C_Spell.IsSpellKnown) or _G.IsSpellKnown
 local CombatLogGetCurrentEventInfo = _G.CombatLogGetCurrentEventInfo
 local IsQuestFlaggedCompleted = _G.C_QuestLog.IsQuestFlaggedCompleted
 local C_Covenants = _G.C_Covenants

--- a/Core/Collections.lua
+++ b/Core/Collections.lua
@@ -68,7 +68,7 @@ function Collections:ScanToys(reason)
 	if not Rarity.toysScanned then
 		if not ToyBox_OnLoad then
 			self:Debug("Loading Blizzard_Collections addon so the ToyBox can be scanned")
-			UIParentLoadAddOn("Blizzard_Collections")
+			LoadAddOnWithErrorHandling("Blizzard_Collections")
 		end
 	end
 

--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -48,7 +48,8 @@ local GetArchaeologyRaceInfo = _G.GetArchaeologyRaceInfo
 local GetStatistic = _G.GetStatistic
 local GetLootSourceInfo = _G.GetLootSourceInfo
 local C_Timer = _G.C_Timer
-local IsSpellKnown = _G.IsSpellKnown
+-- IsSpellKnown was moved to C_Spell.IsSpellKnown in WoW 12.0.0 (Midnight); use with fallback for compatibility
+local IsSpellKnown = (_G.C_Spell and _G.C_Spell.IsSpellKnown) or _G.IsSpellKnown
 local GetCurrentRenownLevel = C_MajorFactions and C_MajorFactions.GetCurrentRenownLevel
 
 -- Addon APIs
@@ -65,7 +66,8 @@ function EventHandlers:Register()
 	self:RegisterEvent("RESEARCH_ARTIFACT_COMPLETE", "OnResearchArtifactComplete")
 	self:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED", "OnCombat") -- Used to detect boss kills that we didn't solo
 	self:RegisterEvent("CURSOR_CHANGED", "OnCursorChanged") -- Fishing detection
-	self:RegisterEvent("UNIT_SPELLCAST_SENT", "OnSpellcastSent") -- Fishing detection
+	-- UNIT_SPELLCAST_SENT was removed in WoW 12.0.0 (Midnight); use UNIT_SPELLCAST_START instead
+	self:RegisterEvent("UNIT_SPELLCAST_START", "OnSpellcastSent") -- Fishing detection
 	self:RegisterEvent("UNIT_SPELLCAST_STOP", "OnSpellcastStopped") -- Fishing detection
 	self:RegisterEvent("UNIT_SPELLCAST_FAILED", "OnSpellcastFailed") -- Fishing detection
 	self:RegisterEvent("UNIT_SPELLCAST_INTERRUPTED", "OnSpellcastFailed") -- Fishing detection
@@ -846,7 +848,9 @@ end
 
 local FISHING_DELAY = 22
 
-function R:OnSpellcastSent(event, unit, target, castGUID, spellID)
+function R:OnSpellcastSent(event, unit, castGUID, spellID)
+	-- Note: Previously used UNIT_SPELLCAST_SENT (removed in 12.0.0), now uses UNIT_SPELLCAST_START
+	-- UNIT_SPELLCAST_START signature: (unit, castGUID, spellID) - no "target" argument
 	if unit ~= "player" then
 		return
 	end

--- a/Core/GUI/DataBrokerDisplay.lua
+++ b/Core/GUI/DataBrokerDisplay.lua
@@ -178,18 +178,34 @@ function GUI:UpdateText()
 	if chance < 0 then
 		chance = 0
 	end
-	local text = format("%s: %d (%.2f%%)", itemName or trackedItem.name, attempts, chance)
+	-- Bar 1
+	if not chance then
+		chance = 0
+	end
+	if chance > 100 then
+		chance = 100
+	end
+	if chance < 0 then
+		chance = 0
+	end
+	local name1 = itemName or trackedItem.name
+	local stats1 = format("%d (%.2f%%)", attempts, chance)
+	-- Name on the left label, stats anchored to the right via timerLabel
 	if not self.bar then
 		self.bar = self.barGroup:NewCounterBar(
 			"Track",
-			text,
+			name1,
 			chance,
 			100,
 			itemTexture or [[Interface\Icons\spell_nature_forceofnature]]
 		)
+		self.bar:SetTimerLabel(stats1)
+		self.bar:ShowTimerLabel()
 	else
 		self.bar:SetIcon(itemTexture or [[Interface\Icons\spell_nature_forceofnature]])
-		self.bar:SetLabel(text)
+		self.bar:SetLabel(name1)
+		self.bar:SetTimerLabel(stats1)
+		self.bar:ShowTimerLabel()
 		self.bar:SetValue(chance, 100)
 		self.GUI:UpdateSparks() -- NOTE: SetValue always enables sparks (remove once fixed)
 	end
@@ -255,18 +271,23 @@ function GUI:UpdateText()
 		if chance < 0 then
 			chance = 0
 		end
-		text = format("%s: %d (%.2f%%)", trackedItem2.name or "", attempts, chance)
+		local name2 = trackedItem2.name or ""
+		local stats2 = format("%d (%.2f%%)", attempts, chance)
 		if not self.bar2 then
 			self.bar2 = self.barGroup:NewCounterBar(
 				"Track2",
-				text,
+				name2,
 				chance,
 				100,
 				itemTexture or [[Interface\Icons\spell_nature_forceofnature]]
 			)
+			self.bar2:SetTimerLabel(stats2)
+			self.bar2:ShowTimerLabel()
 		else
 			self.bar2:SetIcon(itemTexture or [[Interface\Icons\spell_nature_forceofnature]])
-			self.bar2:SetLabel(text)
+			self.bar2:SetLabel(name2)
+			self.bar2:SetTimerLabel(stats2)
+			self.bar2:ShowTimerLabel()
 			self.bar2:SetValue(chance, 100)
 			self.GUI:UpdateSparks() -- NOTE: SetValue always enables sparks (remove once fixed)
 		end

--- a/Core/GUI/MainWindow.lua
+++ b/Core/GUI/MainWindow.lua
@@ -1155,7 +1155,7 @@ local function addGroup(group, requiresGroup)
 										Rarity:Print(text)
 										if CVarCallbackRegistry:GetCVarValueBool("enableFloatingCombatText") then
 											if type(CombatText_AddMessage) == "nil" then
-												UIParentLoadAddOn("Blizzard_CombatText")
+												LoadAddOnWithErrorHandling("Blizzard_CombatText")
 											end
 											CombatText_AddMessage(text, CombatText_StandardScroll, 1, 1, 1, true, false)
 										else

--- a/DB/SharedConstants.lua
+++ b/DB/SharedConstants.lua
@@ -362,6 +362,8 @@ C.AURAS = {
 -- Tooltip Filters (Note: Currently, this system is merely a stub. but more (and custom) filters may be added in the future)
 -- These are used to decide whether the tooltip should be extended to display information about an CONSTANTS.ITEM_TYPES.ITEM for the NPCs listed in its tooltipNpcs table. Useful if we want to draw attention to an CONSTANTS.ITEM_TYPES.ITEM, but not every player can obtain it
 local GetInstanceInfo = GetInstanceInfo
+-- IsSpellKnown was moved to C_Spell.IsSpellKnown in WoW 12.0.0 (Midnight); use with fallback for compatibility
+local IsSpellKnown = (C_Spell and C_Spell.IsSpellKnown) or IsSpellKnown
 C.TOOLTIP_FILTERS = {
 	IS_SPELL_KNOWN = IsSpellKnown,
 	IS_PLAYER_IN_LFR = function()

--- a/Rarity.toc
+++ b/Rarity.toc
@@ -1,6 +1,6 @@
 ## Author: Allara
-## Interface: 120001, 50503, 11508
-## X-Min-Interface: 120001, 50503, 11508
+## Interface: 120005, 120001, 50503, 11508
+## X-Min-Interface: 120005, 120001, 50503, 11508
 ## Title: Rarity
 ## Version: 1.0 (@project-version@)
 ## X-Curse-Project-ID: 30801

--- a/Rarity.toc
+++ b/Rarity.toc
@@ -1,6 +1,6 @@
 ## Author: Allara
-## Interface: 120005, 120001, 50503, 11508
-## X-Min-Interface: 120005, 120001, 50503, 11508
+## Interface: 121000, 120100, 120005, 120001, 50503, 11508
+## X-Min-Interface: 121000, 120100, 120005, 120001, 50503, 11508
 ## Title: Rarity
 ## Version: 1.0 (@project-version@)
 ## X-Curse-Project-ID: 30801


### PR DESCRIPTION
## Changes

- **Rarity.toc**: Bumped interface version to support WoW 12.0.5 and 12.1.0 (120100)
- **DB/SharedConstants.lua**: Added missing constants for 12.0.5 compatibility
- **Core.lua**: Minor adjustments for the new client version
- **Core/EventHandlers.lua**: Fixed event handlers broken by 12.0.5 API changes
- **Core/GUI/DataBrokerDisplay.lua**: Improved tracking bar layout — item name on the left, attempt/chance stats on the right via SetTimerLabel
- **Core/Collections.lua**: Replaced deprecated UIParentLoadAddOn with LoadAddOnWithErrorHandling (API renamed in 12.1.0)
- **Core/GUI/MainWindow.lua**: Same fix as above
